### PR TITLE
Add HTTP and WebSocket endpoints for sandbox services

### DIFF
--- a/orchard_env/README.md
+++ b/orchard_env/README.md
@@ -14,6 +14,9 @@ turns: run commands, upload/download files, apply git patches, open PTY sessions
 - **Any-harness training** — the popular agent harnesses (`codex`, `claude`, `pi`,
   `opencode`, `hermes`) are preinstalled on `PATH` in every sandbox, so you can
   collect rollouts under whichever harness you train against.
+- **Service endpoints** — expose a server running inside a sandbox (an OpenEnv
+  environment server, an MCP server, a dev server) at a URL that HTTP and
+  WebSocket clients outside the cluster can drive. Opt-in.
 
 <p align="center">
   <img src="docs/figures/orchard-architecture.png" alt="Orchard Env architecture" width="850">
@@ -81,6 +84,30 @@ with SandboxClient() as client:
         sandbox.download_file("/workspace/output.txt", "local_output.txt")
         sandbox.apply_patch(patch_content)
 ```
+
+### Talking to a server inside a sandbox
+
+`exec` covers agents that run commands. When the workload is a long-running
+server instead — an OpenEnv environment server, an MCP server, a dev server —
+expose it and drive it over HTTP or WebSocket:
+
+```python
+with SandboxClient() as client:
+    with client.create_sandbox("my-env:latest") as sandbox:
+        sandbox.exec("nohup python -m http.server 8000 > /tmp/log 2>&1 &")
+
+        endpoint = sandbox.expose_service(8000, wait_ready=True, health_path="/")
+        requests.get(f"{endpoint.url}/index.html")   # no API key needed
+        sandbox.revoke_service(8000)
+```
+
+The URL carries its own credential, so clients that cannot set headers (a raw
+WebSocket client, a browser) work unchanged — and appending a path just works,
+so a client that adds `/ws` gets a valid URL. Treat the URL as a bearer token:
+scope it with `ttl_seconds` and revoke it when done.
+
+Requires `ENABLE_SERVICE_ENDPOINTS=true` on the orchestrator. See the
+[API reference](docs/api.md#service-endpoints).
 
 ### Asynchronous client
 
@@ -276,6 +303,28 @@ wherever it is available.
 > a new tag (e.g. `TOOLS_TAG=2026-07-27 ./scripts/build_push.sh tools`) and point
 > `SANDBOX_TOOLS_IMAGE` at it so every node picks up the change.
 
+## Sandbox service endpoints
+
+Off by default. Enable them when something inside the sandbox listens on a port
+and a client outside the cluster needs to talk to it.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `ENABLE_SERVICE_ENDPOINTS` | `false` | Master switch |
+| `SERVICE_PUBLIC_BASE_URL` | — | Public orchestrator URL used to build service URLs |
+| `SERVICE_TRUST_FORWARDED_HEADERS` | `false` | Trust `X-Forwarded-*` when the base URL is unset |
+| `SERVICE_TOKEN_SECRET` | — | HMAC key for service URLs; **set this for multi-replica** |
+| `SERVICE_TOKEN_TTL_SECONDS` | `3600` | Lifetime of a service URL |
+| `SERVICE_RESERVED_PORTS` | — | Extra ports that may never be exposed |
+| `MAX_SERVICES_PER_SANDBOX` | `8` | Ports one sandbox may expose at once |
+| `SERVICE_TRAFFIC_REFRESHES_HEARTBEAT` | `true` | Proxied traffic keeps the sandbox alive |
+
+A service URL is a **bearer credential**: whoever holds it can reach that port
+on that sandbox until it expires. Set `SERVICE_PUBLIC_BASE_URL` so the URL
+cannot be pointed elsewhere by a forged `X-Forwarded-Host`, terminate TLS at
+your ingress, keep URLs out of logs, and revoke them when finished. The in-pod
+agent port is never exposable.
+
 ## Development
 
 ```bash
@@ -297,6 +346,7 @@ export SANDBOX_BASE_URL="http://your-orchestrator-host"
 export SANDBOX_API_KEY="your-api-key"
 python tests/integration/soak.py
 python tests/integration/sandbox_tools.py
+python tests/integration/service_endpoint.py
 ```
 
 See [tests/README.md](tests/README.md) for what each one covers.

--- a/orchard_env/README.md
+++ b/orchard_env/README.md
@@ -106,8 +106,9 @@ WebSocket client, a browser) work unchanged — and appending a path just works,
 so a client that adds `/ws` gets a valid URL. Treat the URL as a bearer token:
 scope it with `ttl_seconds` and revoke it when done.
 
-Requires `ENABLE_SERVICE_ENDPOINTS=true` on the orchestrator. See the
-[API reference](docs/api.md#service-endpoints).
+Requires `ENABLE_SERVICE_ENDPOINTS=true`, a dedicated
+`SERVICE_PUBLIC_BASE_URL`, and `SERVICE_TOKEN_SECRET` on the orchestrator. See
+the [API reference](docs/api.md#service-endpoints).
 
 ### Asynchronous client
 
@@ -311,19 +312,22 @@ and a client outside the cluster needs to talk to it.
 | Setting | Default | Description |
 | --- | --- | --- |
 | `ENABLE_SERVICE_ENDPOINTS` | `false` | Master switch |
-| `SERVICE_PUBLIC_BASE_URL` | — | Public orchestrator URL used to build service URLs |
-| `SERVICE_TRUST_FORWARDED_HEADERS` | `false` | Trust `X-Forwarded-*` when the base URL is unset |
-| `SERVICE_TOKEN_SECRET` | — | HMAC key for service URLs; **set this for multi-replica** |
+| `SERVICE_PUBLIC_BASE_URL` | — | Wildcard template, e.g. `https://{subdomain}.sandboxes.example.net` |
+| `SERVICE_ALLOW_INSECURE_HTTP` | `false` | Development-only HTTP escape hatch |
+| `SERVICE_TOKEN_SECRET` | — | Required HMAC key for service URLs |
 | `SERVICE_TOKEN_TTL_SECONDS` | `3600` | Lifetime of a service URL |
 | `SERVICE_RESERVED_PORTS` | — | Extra ports that may never be exposed |
 | `MAX_SERVICES_PER_SANDBOX` | `8` | Ports one sandbox may expose at once |
 | `SERVICE_TRAFFIC_REFRESHES_HEARTBEAT` | `true` | Proxied traffic keeps the sandbox alive |
+| `SERVICE_PROXY_MAX_REQUEST_BYTES` | `16777216` | Maximum proxied request body |
 
 A service URL is a **bearer credential**: whoever holds it can reach that port
-on that sandbox until it expires. Set `SERVICE_PUBLIC_BASE_URL` so the URL
-cannot be pointed elsewhere by a forged `X-Forwarded-Host`, terminate TLS at
-your ingress, keep URLs out of logs, and revoke them when finished. The in-pod
-agent port is never exposable.
+on that sandbox until it expires. `SERVICE_PUBLIC_BASE_URL` must be a wildcard
+HTTPS template on a separate registrable domain from the management API.
+Orchard gives every capability a different hostname, which is the browser
+security boundary between hostile sandbox services. Configure wildcard DNS and
+TLS, redact `/s/*` in ingress logs, keep URLs out of traces and referrers, and
+revoke them when finished. The in-pod agent port is never exposable.
 
 ## Development
 

--- a/orchard_env/docs/api.md
+++ b/orchard_env/docs/api.md
@@ -37,6 +37,11 @@ export BASE_URL=http://localhost:8000
 | `POST` | `/sandboxes/{sandbox_id}/files` | Upload a file |
 | `GET` | `/sandboxes/{sandbox_id}/files` | Download a file |
 | `GET` | `/sandboxes/{sandbox_id}/files/list` | List a directory |
+| `POST` | `/sandboxes/{sandbox_id}/services` | Expose a service port |
+| `GET` | `/sandboxes/{sandbox_id}/services` | List exposed ports |
+| `DELETE` | `/sandboxes/{sandbox_id}/services/{port}` | Revoke an exposed port |
+| `ANY` | `/s/{token}/{path}` | Proxy HTTP to a sandbox service |
+| `WS` | `/s/{token}/{path}` | Proxy a WebSocket to a sandbox service |
 | `GET` | `/jobs/{job_id}` | Get job status and results |
 | `GET` | `/jobs/{job_id}/wait` | Block until the job completes |
 
@@ -197,6 +202,116 @@ X-API-Key: your-api-key
 ```
 
 `size` is an integer (bytes). `type` is `"file"` or `"directory"`.
+
+### Service endpoints
+
+Exec and file I/O cover agents that *run commands*. Some workloads instead
+speak a protocol to a long-running server inside the sandbox — an OpenEnv
+environment server, an MCP server, a dev server, an evaluation endpoint. Those
+need a reachable URL.
+
+Disabled by default. Set `ENABLE_SERVICE_ENDPOINTS=true` on the orchestrator to
+turn them on.
+
+#### Expose a port
+
+```http
+POST /sandboxes/{sandbox_id}/services
+Content-Type: application/json
+X-API-Key: your-api-key
+
+{
+  "port": 8000,
+  "ttl_seconds": 3600,
+  "wait_ready": true,
+  "health_path": "/health",
+  "ready_timeout": 60
+}
+```
+
+```json
+{
+  "sandbox_id": "abc12345",
+  "port": 8000,
+  "url": "https://orchestrator.example.com/s/eyJ...signed-token",
+  "expires_at": 1702903600.0
+}
+```
+
+`wait_ready` blocks until the service answers `health_path`. This is worth
+setting: a sandbox reports ready when the *in-pod agent* is up, which can be
+well before a server you just launched has finished binding.
+
+Re-exposing an already-exposed port is not an error, so a client that retries
+after a network blip does not need to special-case it.
+
+**The returned URL is a bearer credential.** Anyone holding it can reach that
+port on that sandbox until it expires. Keep it out of logs, scope it with
+`ttl_seconds`, and revoke it when the work is done.
+
+#### Use the endpoint
+
+The token travels in the path, so no header is required — which is the point:
+clients that cannot set headers (a raw WebSocket client, a browser) still work.
+Appending a path also just works, so an OpenEnv client that adds `/ws` produces
+a valid URL with no special-casing.
+
+```bash
+curl "$URL/health"                       # HTTP
+websocat "${URL/https:/wss:}/ws"         # WebSocket
+```
+
+Every request re-checks the signature, the expiry, that the sandbox still
+exists, and that the port is still exposed.
+
+#### List and revoke
+
+```http
+GET /sandboxes/{sandbox_id}/services
+X-API-Key: your-api-key
+```
+
+```json
+{ "sandbox_id": "abc12345", "ports": [8000] }
+```
+
+```http
+DELETE /sandboxes/{sandbox_id}/services/8000
+X-API-Key: your-api-key
+```
+
+```json
+{ "status": "revoked", "sandbox_id": "abc12345", "port": 8000 }
+```
+
+Revocation is immediate: URLs that have not yet expired stop working, because
+the allowlist is consulted on every request.
+
+#### Security notes
+
+- The in-pod agent port (`AGENT_PORT`, default `9090`) can never be exposed —
+  it would hand out unauthenticated exec and file access inside the sandbox.
+  `SERVICE_RESERVED_PORTS` adds more ports to that list.
+- Terminate TLS at your ingress. Set `SERVICE_PUBLIC_BASE_URL` to the
+  orchestrator's public `https://` address so service URLs are `https://` and
+  WebSockets are `wss://`. This also stops a forged `X-Forwarded-Host` from
+  redirecting the URL — and the credential in it — to another domain.
+- In a multi-replica deployment set `SERVICE_TOKEN_SECRET` so every replica
+  validates tokens minted by any other. Without it the key is derived from the
+  configured API keys, or generated per process as a last resort.
+- Proxied traffic refreshes the sandbox's liveness timer by default
+  (`SERVICE_TRAFFIC_REFRESHES_HEARTBEAT`), so an actively used service is not
+  reaped mid-session.
+
+| Status | Meaning |
+| --- | --- |
+| `400` | Port is out of range or reserved |
+| `403` | Token is invalid, expired, or the port is no longer exposed |
+| `404` | Sandbox not found, or service endpoints are disabled |
+| `408` | `wait_ready` timed out |
+| `409` | Sandbox already exposes `MAX_SERVICES_PER_SANDBOX` ports |
+| `502` | Service inside the sandbox is unreachable |
+| `504` | Service did not respond in time |
 
 ### Delete a sandbox
 

--- a/orchard_env/docs/api.md
+++ b/orchard_env/docs/api.md
@@ -233,7 +233,7 @@ X-API-Key: your-api-key
 {
   "sandbox_id": "abc12345",
   "port": 8000,
-  "url": "https://orchestrator.example.com/s/eyJ...signed-token",
+  "url": "https://7f0a...c3.sandboxes.example.net/s/eyJ...signed-token",
   "expires_at": 1702903600.0
 }
 ```
@@ -242,8 +242,8 @@ X-API-Key: your-api-key
 setting: a sandbox reports ready when the *in-pod agent* is up, which can be
 well before a server you just launched has finished binding.
 
-Re-exposing an already-exposed port is not an error, so a client that retries
-after a network blip does not need to special-case it.
+Re-exposing an active port is idempotent. After revocation, exposing the same
+port creates a new generation, so old unexpired URLs stay invalid.
 
 **The returned URL is a bearer credential.** Anyone holding it can reach that
 port on that sandbox until it expires. Keep it out of logs, scope it with
@@ -284,24 +284,32 @@ X-API-Key: your-api-key
 { "status": "revoked", "sandbox_id": "abc12345", "port": 8000 }
 ```
 
-Revocation is immediate: URLs that have not yet expired stop working, because
-the allowlist is consulted on every request.
+Revocation is immediate and permanent for that URL: the active generation is
+consulted on every request, and re-exposure creates a different generation.
 
 #### Security notes
 
 - The in-pod agent port (`AGENT_PORT`, default `9090`) can never be exposed —
   it would hand out unauthenticated exec and file access inside the sandbox.
   `SERVICE_RESERVED_PORTS` adds more ports to that list.
-- Terminate TLS at your ingress. Set `SERVICE_PUBLIC_BASE_URL` to the
-  orchestrator's public `https://` address so service URLs are `https://` and
-  WebSockets are `wss://`. This also stops a forged `X-Forwarded-Host` from
-  redirecting the URL — and the credential in it — to another domain.
-- In a multi-replica deployment set `SERVICE_TOKEN_SECRET` so every replica
-  validates tokens minted by any other. Without it the key is derived from the
-  configured API keys, or generated per process as a last resort.
+- `SERVICE_PUBLIC_BASE_URL` is required and must contain one `{subdomain}`
+  placeholder, for example
+  `https://{subdomain}.sandboxes.example.net`. Configure wildcard DNS and TLS
+  on a separate registrable domain from the management API. Every capability
+  receives a different hostname, isolating browser origin state. The
+  management API is refused on all matching service hostnames, and capability
+  routes are refused elsewhere.
+- `SERVICE_TOKEN_SECRET` is required. Use a separate random secret, not a
+  management API key.
+- Capability tokens appear in request paths. Orchard disables its own Uvicorn
+  access log, but ingress, load-balancer, and tracing systems must also redact
+  `/s/*`. Avoid putting service URLs in referrers or durable logs.
+- Management credentials (`X-API-Key`, `Authorization`, and cookies) are never
+  forwarded into sandbox code. Sandbox `Set-Cookie` and
+  `Service-Worker-Allowed` response headers are stripped.
 - Proxied traffic refreshes the sandbox's liveness timer by default
-  (`SERVICE_TRAFFIC_REFRESHES_HEARTBEAT`), so an actively used service is not
-  reaped mid-session.
+  for the full lifetime of an HTTP stream or WebSocket, so an active service
+  is not reaped mid-session.
 
 | Status | Meaning |
 | --- | --- |
@@ -310,6 +318,7 @@ the allowlist is consulted on every request.
 | `404` | Sandbox not found, or service endpoints are disabled |
 | `408` | `wait_ready` timed out |
 | `409` | Sandbox already exposes `MAX_SERVICES_PER_SANDBOX` ports |
+| `413` | Request body exceeds `SERVICE_PROXY_MAX_REQUEST_BYTES` |
 | `502` | Service inside the sandbox is unreachable |
 | `504` | Service did not respond in time |
 

--- a/orchard_env/docs/architecture.md
+++ b/orchard_env/docs/architecture.md
@@ -121,6 +121,8 @@ backoff and jitter. See the [SDK reference](sdk.md).
 | `sandbox_manager.py` | Sandbox lifecycle, pod-IP caching, TTL/heartbeat cleanup, cluster reconciliation |
 | `exec_manager.py` | Submits exec jobs, serialises them per sandbox, bounds global concurrency, retries agent-connect failures |
 | `agent_client.py` | Pooled `aiohttp` client that talks directly to pod IPs |
+| `service_proxy.py` | Pooled `aiohttp` client and helpers for proxying user services inside sandboxes (port allowlisting, header filtering) |
+| `service_tokens.py` | Mint and verify the signed, expiring capability tokens that authenticate service URLs |
 | `k8s_client.py` | Kubernetes API wrapper — pod spec construction, network policies, throttling, retries |
 | `pod_watcher.py` | Kubernetes `Watch` informer keeping live pod phase and pod IP in memory |
 | `job_store.py` / `redis_job_store.py` | Job state — in-memory (single replica) or Redis (multi-replica) |
@@ -224,6 +226,38 @@ client falls back to polling `GET /jobs/{id}`. **A `"running"` status never mean
 Uploads, downloads, and listings take the same route: the orchestrator resolves
 the pod IP and forwards a base64 payload to the agent. `apply_patch()` writes the
 diff into the sandbox and runs `git apply` through the exec path.
+
+### Proxy to a service inside a sandbox
+
+```
+sandbox.expose_service(8000)
+   │
+   └─► POST /sandboxes/{id}/services
+          ├── refuse the agent port and any operator-reserved port
+          ├── add 8000 to the sandbox record's exposed_ports (Redis or memory)
+          ├── optionally poll the service's own health path
+          └── mint an HMAC capability token naming (sandbox, port, expiry)
+                 → https://orchestrator/s/<token>
+
+GET  https://orchestrator/s/<token>/health
+WS   wss://orchestrator/s/<token>/ws
+   │
+   └─► verify signature → check expiry → sandbox still exists?
+          → port still in exposed_ports?  (this is what makes revocation instant)
+          → resolve pod IP from the PodWatcher cache
+          → forward to pod:8000, stripping hop-by-hop headers
+```
+
+Two things distinguish this from the exec path. The credential lives in the URL
+rather than a header, because the clients that need it — a raw WebSocket client,
+a browser — cannot attach one. And the token is a *stateless* HMAC, so any
+replica validates a token minted by any other without shared state, while
+revocation still takes effect immediately because the allowlist is re-read on
+every request.
+
+Kubernetes note: the pod spec is unchanged. `containerPort` is informational, so
+any process listening on `0.0.0.0` inside the pod is already reachable at the pod
+IP. What this adds is reachability from *outside* the cluster.
 
 ### Delete a sandbox
 

--- a/orchard_env/docs/architecture.md
+++ b/orchard_env/docs/architecture.md
@@ -234,26 +234,35 @@ sandbox.expose_service(8000)
    │
    └─► POST /sandboxes/{id}/services
           ├── refuse the agent port and any operator-reserved port
-          ├── add 8000 to the sandbox record's exposed_ports (Redis or memory)
           ├── optionally poll the service's own health path
-          └── mint an HMAC capability token naming (sandbox, port, expiry)
-                 → https://orchestrator/s/<token>
+          ├── store (port → generation) outside the sandbox JSON record
+          └── mint an HMAC capability naming
+              (sandbox, port, generation, expiry)
+                 → https://<capability>.sandboxes.example.net/s/<token>
 
-GET  https://orchestrator/s/<token>/health
-WS   wss://orchestrator/s/<token>/ws
+GET  https://<capability>.sandboxes.example.net/s/<token>/health
+WS   wss://<capability>.sandboxes.example.net/s/<token>/ws
    │
    └─► verify signature → check expiry → sandbox still exists?
-          → port still in exposed_ports?  (this is what makes revocation instant)
+          → generation still active?  (revocation never revives on re-expose)
           → resolve pod IP from the PodWatcher cache
-          → forward to pod:8000, stripping hop-by-hop headers
+          → forward to pod:8000, pinned against cross-destination redirects
 ```
 
 Two things distinguish this from the exec path. The credential lives in the URL
 rather than a header, because the clients that need it — a raw WebSocket client,
 a browser — cannot attach one. And the token is a *stateless* HMAC, so any
 replica validates a token minted by any other without shared state, while
-revocation still takes effect immediately because the allowlist is re-read on
-every request.
+revocation still takes effect immediately because the active generation is
+re-read on every request. Service state lives in a separate Redis hash so older
+replicas can continue reading the unchanged sandbox-record schema during a
+rolling upgrade.
+
+Each capability receives a different hostname under a wildcard service domain,
+so hostile browser state is isolated between services as well as from the
+management API. Management credentials and cookies are stripped before
+forwarding, while sandbox cookies and broad service-worker headers are stripped
+on the way back.
 
 Kubernetes note: the pod spec is unchanged. `containerPort` is informational, so
 any process listening on `0.0.0.0` inside the pod is already reachable at the pod
@@ -310,6 +319,11 @@ runs its own `PodWatcher`, so pod-IP lookups stay local and free.
 
 With `USE_REDIS=false` the orchestrator keeps everything in memory and **must**
 run as a single replica.
+
+The reference Redis deployment requires authentication and applies an ingress
+NetworkPolicy that permits only `app=sandbox-orchestrator` pods. This is a
+control-plane boundary: a sandbox with egress enabled must not be able to
+restore revoked capability generations or alter lifecycle state.
 
 ## Throughput notes
 

--- a/orchard_env/docs/deployment.md
+++ b/orchard_env/docs/deployment.md
@@ -243,7 +243,33 @@ matching upper-case environment variable.
 | `REDIS_URL` | in-cluster Redis | Redis connection URL |
 | `REQUIRE_API_KEY` | `true` | Enforce `X-API-Key` |
 | `API_KEYS` | (secret) | Comma/whitespace-separated valid keys |
+| `ENABLE_SERVICE_ENDPOINTS` | `false` | Allow exposing services inside sandboxes |
+| `SERVICE_PUBLIC_BASE_URL` | — | Public URL of the orchestrator, e.g. `https://orchard.example.com` |
+| `SERVICE_TRUST_FORWARDED_HEADERS` | `false` | Trust `X-Forwarded-Proto`/`X-Forwarded-Host` when the base URL is unset |
+| `SERVICE_TOKEN_SECRET` | — | HMAC key for service URLs; **set this for multi-replica** |
+| `SERVICE_TOKEN_TTL_SECONDS` | `3600` | Lifetime of a service URL |
+| `SERVICE_RESERVED_PORTS` | — | Extra ports that may never be exposed |
+| `MAX_SERVICES_PER_SANDBOX` | `8` | Ports one sandbox may expose at once |
+| `SERVICE_TRAFFIC_REFRESHES_HEARTBEAT` | `true` | Proxied traffic keeps the sandbox alive |
+| `SERVICE_PROXY_TIMEOUT_SECONDS` | `300` | Upstream request timeout |
+| `SERVICE_PROXY_MAX_MESSAGE_BYTES` | `16777216` | Max proxied WebSocket frame |
 | `LOG_LEVEL` / `LOG_FORMAT` | `INFO` / `json` | Logging |
+
+Service endpoints are off by default because they deliberately open a hole in
+the sandbox boundary. When enabling them:
+
+- Set `SERVICE_PUBLIC_BASE_URL` to the orchestrator's public URL. The service
+  URL contains a credential, so where it points matters: without this the URL
+  is derived from request headers, and a forged `X-Forwarded-Host` would send
+  the caller — and the token — to an attacker's domain. Only set
+  `SERVICE_TRUST_FORWARDED_HEADERS=true` if a proxy you control overwrites
+  those headers on every request.
+- Set `SERVICE_TOKEN_SECRET` if you run more than one replica, so every replica
+  validates URLs minted by any other.
+- Terminate TLS at the ingress, and point `SERVICE_PUBLIC_BASE_URL` at the
+  `https://` address so WebSocket URLs become `wss://`.
+- The agent port (`AGENT_PORT`) is always refused; add anything else sensitive
+  to `SERVICE_RESERVED_PORTS`.
 
 Apply changes with:
 

--- a/orchard_env/docs/deployment.md
+++ b/orchard_env/docs/deployment.md
@@ -241,33 +241,37 @@ matching upper-case environment variable.
 | `HEARTBEAT_TIMEOUT_SECONDS` | `600` | Sandbox considered dead without a heartbeat |
 | `USE_REDIS` | `true` | Required for more than one replica |
 | `REDIS_URL` | in-cluster Redis | Redis connection URL |
+| `REDIS_PASSWORD` | (secret) | Required unless the password is embedded in `REDIS_URL` |
+| `REDIS_REQUIRE_AUTH` | `true` | Fail closed when Redis has no credentials |
 | `REQUIRE_API_KEY` | `true` | Enforce `X-API-Key` |
 | `API_KEYS` | (secret) | Comma/whitespace-separated valid keys |
 | `ENABLE_SERVICE_ENDPOINTS` | `false` | Allow exposing services inside sandboxes |
-| `SERVICE_PUBLIC_BASE_URL` | — | Public URL of the orchestrator, e.g. `https://orchard.example.com` |
-| `SERVICE_TRUST_FORWARDED_HEADERS` | `false` | Trust `X-Forwarded-Proto`/`X-Forwarded-Host` when the base URL is unset |
-| `SERVICE_TOKEN_SECRET` | — | HMAC key for service URLs; **set this for multi-replica** |
+| `SERVICE_PUBLIC_BASE_URL` | — | Wildcard template, e.g. `https://{subdomain}.sandboxes.example.net` |
+| `SERVICE_ALLOW_INSECURE_HTTP` | `false` | Development-only HTTP escape hatch |
+| `SERVICE_TOKEN_SECRET` | — | Required HMAC key for service URLs |
 | `SERVICE_TOKEN_TTL_SECONDS` | `3600` | Lifetime of a service URL |
 | `SERVICE_RESERVED_PORTS` | — | Extra ports that may never be exposed |
 | `MAX_SERVICES_PER_SANDBOX` | `8` | Ports one sandbox may expose at once |
 | `SERVICE_TRAFFIC_REFRESHES_HEARTBEAT` | `true` | Proxied traffic keeps the sandbox alive |
+| `SERVICE_ACTIVE_HEARTBEAT_INTERVAL_SECONDS` | `60` | Refresh interval during active streams/sockets |
 | `SERVICE_PROXY_TIMEOUT_SECONDS` | `300` | Upstream request timeout |
+| `SERVICE_PROXY_HANDSHAKE_TIMEOUT_SECONDS` | `15` | WebSocket handshake deadline |
+| `SERVICE_PROXY_MAX_REQUEST_BYTES` | `16777216` | Max proxied request body |
 | `SERVICE_PROXY_MAX_MESSAGE_BYTES` | `16777216` | Max proxied WebSocket frame |
 | `LOG_LEVEL` / `LOG_FORMAT` | `INFO` / `json` | Logging |
 
 Service endpoints are off by default because they deliberately open a hole in
 the sandbox boundary. When enabling them:
 
-- Set `SERVICE_PUBLIC_BASE_URL` to the orchestrator's public URL. The service
-  URL contains a credential, so where it points matters: without this the URL
-  is derived from request headers, and a forged `X-Forwarded-Host` would send
-  the caller — and the token — to an attacker's domain. Only set
-  `SERVICE_TRUST_FORWARDED_HEADERS=true` if a proxy you control overwrites
-  those headers on every request.
-- Set `SERVICE_TOKEN_SECRET` if you run more than one replica, so every replica
-  validates URLs minted by any other.
-- Terminate TLS at the ingress, and point `SERVICE_PUBLIC_BASE_URL` at the
-  `https://` address so WebSocket URLs become `wss://`.
+- Set `SERVICE_PUBLIC_BASE_URL` to a wildcard HTTPS template for sandbox
+  traffic, such as `https://{subdomain}.sandboxes.example.net`, on a separate
+  registrable domain from the management API. Configure matching wildcard DNS
+  and TLS. Each capability receives a different hostname, isolating browser
+  localStorage, IndexedDB, caches, BroadcastChannel, and other origin state.
+- Set `SERVICE_TOKEN_SECRET` to a separate random value. The feature fails
+  closed when it is absent.
+- Route only `/s/*` to the service origin, and redact that path in ingress,
+  load-balancer, and trace logs because it contains a bearer capability.
 - The agent port (`AGENT_PORT`) is always refused; add anything else sensitive
   to `SERVICE_RESERVED_PORTS`.
 
@@ -280,8 +284,10 @@ kubectl rollout restart deployment/sandbox-orchestrator -n orchestrator
 
 ### Redis
 
-Redis shares sandbox and job state between orchestrator replicas and provides the
-distributed exec locks. It is enabled by default.
+Redis shares sandbox and job state between orchestrator replicas and provides
+the distributed exec locks. It is enabled by default. The reference deployment
+requires `REDIS_PASSWORD` and applies an ingress NetworkPolicy that allows only
+orchestrator pods; even a sandbox with `block_network=false` cannot reach it.
 
 ```bash
 kubectl apply -f k8s/redis.yaml            # deploy in-cluster Redis
@@ -291,8 +297,9 @@ kubectl apply -f k8s/redis.yaml            # deploy in-cluster Redis
 # single replica only — configmap.yaml
 USE_REDIS: "false"
 
-# or point at a managed instance
-REDIS_URL: "redis://:password@your-redis.example.com:6380/0?ssl=true"
+# or point at a managed instance (prefer a secret REDIS_PASSWORD)
+REDIS_URL: "rediss://your-redis.example.com:6380/0"
+REDIS_PASSWORD: "..."
 ```
 
 ### Sandbox resource limits

--- a/orchard_env/docs/sdk.md
+++ b/orchard_env/docs/sdk.md
@@ -66,12 +66,49 @@ API — needs `block_network=False`.
 | `download_file(remote_path, local_path)` | Download a file |
 | `download_content(remote_path)` | Download file content as bytes |
 | `list_files(remote_path)` | List a directory |
+| `expose_service(port, ...)` | Expose a service inside the sandbox, returns `ServiceEndpoint` |
+| `list_services()` | List exposed ports |
+| `revoke_service(port)` | Stop exposing a port |
+| `heartbeat()` | Send one heartbeat now |
+| `start_heartbeat(interval)` / `stop_heartbeat()` | Background heartbeat loop |
 | `get_job(job_id)` | Fetch job status and results |
 | `delete()` | Delete the sandbox |
 
 `exec()` also accepts `login_shell=True` (runs under `bash -lc` instead of
 `bash -c`) and `pty=True` for an interactive session backed by
 `ContainerProcess` / `AsyncContainerProcess`.
+
+## `ServiceEndpoint`
+
+`exec` and the file methods cover agents that *run commands*. When the workload
+is instead a long-running server inside the sandbox — an OpenEnv environment
+server, an MCP server, a dev server — `expose_service()` returns a URL a client
+outside the cluster can talk to.
+
+```python
+sandbox.exec("nohup python -m http.server 8000 > /tmp/log 2>&1 &")
+
+endpoint = sandbox.expose_service(8000, wait_ready=True, health_path="/")
+endpoint.url         # https://orchestrator/s/<token>
+endpoint.ws_url      # wss://orchestrator/s/<token>
+endpoint.port
+endpoint.expires_at
+
+requests.get(f"{endpoint.url}/index.html")
+sandbox.revoke_service(8000)
+```
+
+`wait_ready=True` is worth setting: a sandbox reports ready once the *in-pod
+agent* is up, which can be well before a server you just launched has finished
+binding.
+
+> **The URL is a bearer credential.** Anyone holding it can reach that port on
+> that sandbox until `expires_at`. Keep it out of logs, scope it with
+> `ttl_seconds`, and call `revoke_service()` when finished — revocation takes
+> effect immediately, even for URLs that have not expired. `repr()` deliberately
+> omits the URL so it does not leak into log lines.
+
+Requires `ENABLE_SERVICE_ENDPOINTS=true` on the orchestrator.
 
 ## `JobResult`
 

--- a/orchard_env/k8s/configmap.yaml
+++ b/orchard_env/k8s/configmap.yaml
@@ -51,6 +51,21 @@ data:
   SANDBOX_TOOLS_VOLUME_MODE: "image"
   SANDBOX_TOOLS_MOUNT_PATH: "/opt/sandbox-tools"
   
+  # Sandbox service endpoints — proxy HTTP/WebSocket to a user service running
+  # inside a sandbox (OpenEnv env server, MCP server, dev server).
+  # Off by default: it deliberately opens a hole in the sandbox boundary.
+  # With more than one replica, set SERVICE_TOKEN_SECRET in the Secret so every
+  # replica validates URLs minted by any other.
+  ENABLE_SERVICE_ENDPOINTS: "false"
+  SERVICE_PUBLIC_BASE_URL: ""
+  SERVICE_TRUST_FORWARDED_HEADERS: "false"
+  SERVICE_TOKEN_TTL_SECONDS: "3600"
+  MAX_SERVICES_PER_SANDBOX: "8"
+  SERVICE_RESERVED_PORTS: ""
+  SERVICE_TRAFFIC_REFRESHES_HEARTBEAT: "true"
+  SERVICE_PROXY_TIMEOUT_SECONDS: "300"
+  SERVICE_PROXY_MAX_MESSAGE_BYTES: "16777216"
+
   # TTL settings
   SANDBOX_TTL_HOURS: "2"
   ORPHAN_JOB_TTL_HOURS: "1"

--- a/orchard_env/k8s/configmap.yaml
+++ b/orchard_env/k8s/configmap.yaml
@@ -54,17 +54,22 @@ data:
   # Sandbox service endpoints — proxy HTTP/WebSocket to a user service running
   # inside a sandbox (OpenEnv env server, MCP server, dev server).
   # Off by default: it deliberately opens a hole in the sandbox boundary.
-  # With more than one replica, set SERVICE_TOKEN_SECRET in the Secret so every
-  # replica validates URLs minted by any other.
   ENABLE_SERVICE_ENDPOINTS: "false"
   SERVICE_PUBLIC_BASE_URL: ""
-  SERVICE_TRUST_FORWARDED_HEADERS: "false"
+  SERVICE_ALLOW_INSECURE_HTTP: "false"
   SERVICE_TOKEN_TTL_SECONDS: "3600"
   MAX_SERVICES_PER_SANDBOX: "8"
   SERVICE_RESERVED_PORTS: ""
   SERVICE_TRAFFIC_REFRESHES_HEARTBEAT: "true"
+  SERVICE_ACTIVE_HEARTBEAT_INTERVAL_SECONDS: "60"
   SERVICE_PROXY_TIMEOUT_SECONDS: "300"
+  SERVICE_PROXY_HANDSHAKE_TIMEOUT_SECONDS: "15"
+  SERVICE_PROXY_MAX_REQUEST_BYTES: "16777216"
   SERVICE_PROXY_MAX_MESSAGE_BYTES: "16777216"
+
+  # Redis authentication is mandatory in the reference deployment. The
+  # password comes from orchestrator-api-keys via envFrom.
+  REDIS_REQUIRE_AUTH: "true"
 
   # TTL settings
   SANDBOX_TTL_HOURS: "2"

--- a/orchard_env/k8s/redis.yaml
+++ b/orchard_env/k8s/redis.yaml
@@ -21,6 +21,19 @@ spec:
         - name: redis
           image: ${ACR_NAME}.azurecr.io/redis:7-alpine
           imagePullPolicy: IfNotPresent
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: orchestrator-api-keys
+                  key: REDIS_PASSWORD
+            # redis-cli reads this automatically, so probes authenticate
+            # without putting the password in command arguments or logs.
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: orchestrator-api-keys
+                  key: REDIS_PASSWORD
           ports:
             - containerPort: 6379
           resources:
@@ -32,12 +45,15 @@ spec:
               memory: 16Gi
           command:
             - redis-server
+          args:
             - --appendonly
             - "yes"
             - --maxmemory
             - 10gb
             - --maxmemory-policy
             - allkeys-lru
+            - --requirepass
+            - $(REDIS_PASSWORD)
           volumeMounts:
             - name: redis-data
               mountPath: /data
@@ -75,3 +91,27 @@ spec:
     - port: 6379
       targetPort: 6379
   type: ClusterIP
+---
+# Redis carries sandbox lifecycle, capability generations, and pod targets.
+# Even a sandbox with block_network=false must never reach it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-orchestrator-only
+  namespace: orchestrator
+  labels:
+    app: redis
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: sandbox-orchestrator
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/orchard_env/k8s/secret.example.yaml
+++ b/orchard_env/k8s/secret.example.yaml
@@ -17,3 +17,8 @@ stringData:
     REPLACE_WITH_GENERATED_KEY_1,
     REPLACE_WITH_GENERATED_KEY_2,
     REPLACE_WITH_GENERATED_KEY_3
+  # Required when ENABLE_SERVICE_ENDPOINTS=true. Use a separate random value,
+  # not one of the management API keys.
+  SERVICE_TOKEN_SECRET: REPLACE_WITH_A_RANDOM_32_BYTE_SECRET
+  # Required by the reference Redis deployment and the orchestrator client.
+  REDIS_PASSWORD: REPLACE_WITH_A_DIFFERENT_RANDOM_32_BYTE_SECRET

--- a/orchard_env/orchard_env/__init__.py
+++ b/orchard_env/orchard_env/__init__.py
@@ -7,6 +7,7 @@ from orchard_env.client.sandbox_client import (
     JobResult,
     SandboxClient,
     SandboxInstance,
+    ServiceEndpoint,
 )
 
 __version__ = "0.1.0"
@@ -17,6 +18,7 @@ __all__ = [
     "SandboxInstance",
     "AsyncSandboxInstance",
     "JobResult",
+    "ServiceEndpoint",
     "ContainerProcess",
     "AsyncContainerProcess",
 ]

--- a/orchard_env/orchard_env/client/sandbox_client.py
+++ b/orchard_env/orchard_env/client/sandbox_client.py
@@ -129,6 +129,34 @@ class JobResult:
         return f"JobResult(status={self.status}, exit_code={self.exit_code})"
 
 
+class ServiceEndpoint:
+    """A URL for a service running inside a sandbox.
+
+    Returned by :meth:`SandboxInstance.expose_service`. The URL carries its own
+    credential, so it is a bearer token: anyone holding it can reach that port
+    on that sandbox until ``expires_at``, or until the port is revoked.
+    """
+
+    def __init__(self, data: dict):
+        self.sandbox_id: str = data.get("sandbox_id", "")
+        self.port: int = data.get("port", 0)
+        self.url: str = data.get("url", "")
+        self.expires_at: float = data.get("expires_at", 0.0)
+
+    @property
+    def ws_url(self) -> str:
+        """The same endpoint as a ``ws://``/``wss://`` URL."""
+        if self.url.startswith("https://"):
+            return "wss://" + self.url[len("https://") :]
+        if self.url.startswith("http://"):
+            return "ws://" + self.url[len("http://") :]
+        return self.url
+
+    def __repr__(self) -> str:
+        # The URL is a credential, so it is deliberately not in the repr.
+        return f"ServiceEndpoint(sandbox_id={self.sandbox_id}, port={self.port})"
+
+
 class SandboxInstance:
     """A sandbox instance that supports command execution."""
 
@@ -176,6 +204,79 @@ class SandboxInstance:
         if self._heartbeat_thread:
             self._heartbeat_thread.join(timeout=5)
             self._heartbeat_thread = None
+
+    def heartbeat(self) -> None:
+        """Send a single heartbeat now.
+
+        :meth:`start_heartbeat` owns a background thread, which is the right
+        shape for a long-lived session. Callers driving their own loop — an RL
+        rollout that already ticks per step, or an adapter implementing another
+        framework's heartbeat hook — want one call instead.
+        """
+        self._client._request("POST", f"/sandboxes/{self.sandbox_id}/heartbeat")
+
+    def expose_service(
+        self,
+        port: int,
+        ttl_seconds: int | None = None,
+        wait_ready: bool = False,
+        health_path: str = "/health",
+        ready_timeout: int = 60,
+    ) -> "ServiceEndpoint":
+        """Expose a service running inside the sandbox and return its URL.
+
+        The sandbox agent handles commands and files; this is for a *server*
+        running in the sandbox that a client needs to speak a protocol to — an
+        OpenEnv environment server, an MCP server, a dev server.
+
+        The returned URL authenticates itself, so it works with clients that
+        cannot attach an ``X-API-Key`` header (a raw WebSocket client, a
+        browser). Treat it as a bearer credential: scope it with ``ttl_seconds``
+        and keep it out of logs.
+
+        Args:
+            port: Port the service listens on inside the sandbox.
+            ttl_seconds: Lifetime of the URL. Server default if omitted.
+            wait_ready: Block until the service answers ``health_path``. The
+                sandbox being ready only means the *agent* is up, so a server
+                you just launched may still be starting.
+            health_path: Path polled when ``wait_ready`` is true.
+            ready_timeout: Seconds to wait when ``wait_ready`` is true.
+
+        Returns:
+            ServiceEndpoint: Carries ``url``, ``port``, and ``expires_at``.
+
+        Example::
+
+            sandbox.exec("nohup python -m http.server 8000 &")
+            endpoint = sandbox.expose_service(8000, wait_ready=True, health_path="/")
+            requests.get(endpoint.url)
+        """
+        payload = {
+            "port": port,
+            "wait_ready": wait_ready,
+            "health_path": health_path,
+            "ready_timeout": ready_timeout,
+        }
+        if ttl_seconds is not None:
+            payload["ttl_seconds"] = ttl_seconds
+
+        data = self._client._request(
+            "POST", f"/sandboxes/{self.sandbox_id}/services", json=payload
+        )
+        return ServiceEndpoint(data)
+
+    def list_services(self) -> list[int]:
+        """Return the ports this sandbox currently exposes."""
+        data = self._client._request("GET", f"/sandboxes/{self.sandbox_id}/services")
+        return data.get("ports", [])
+
+    def revoke_service(self, port: int) -> None:
+        """Stop exposing *port*.
+
+        Effective immediately, including for URLs that have not yet expired.
+        """
+        self._client._request("DELETE", f"/sandboxes/{self.sandbox_id}/services/{port}")
 
     def exec(
         self,
@@ -972,6 +1073,57 @@ class AsyncSandboxInstance:
         if self._heartbeat_task and not self._heartbeat_task.done():
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
+
+    async def heartbeat(self) -> None:
+        """Send a single heartbeat now.
+
+        The async counterpart to :meth:`SandboxInstance.heartbeat`; see there
+        for when to prefer this over :meth:`start_heartbeat`.
+        """
+        await self._client._request("POST", f"/sandboxes/{self.sandbox_id}/heartbeat")
+
+    async def expose_service(
+        self,
+        port: int,
+        ttl_seconds: int | None = None,
+        wait_ready: bool = False,
+        health_path: str = "/health",
+        ready_timeout: int = 60,
+    ) -> "ServiceEndpoint":
+        """Expose a service running inside the sandbox and return its URL.
+
+        The async counterpart to :meth:`SandboxInstance.expose_service`; see
+        there for the full description and the bearer-credential caveat.
+        """
+        payload = {
+            "port": port,
+            "wait_ready": wait_ready,
+            "health_path": health_path,
+            "ready_timeout": ready_timeout,
+        }
+        if ttl_seconds is not None:
+            payload["ttl_seconds"] = ttl_seconds
+
+        data = await self._client._request(
+            "POST", f"/sandboxes/{self.sandbox_id}/services", json=payload
+        )
+        return ServiceEndpoint(data)
+
+    async def list_services(self) -> list[int]:
+        """Return the ports this sandbox currently exposes."""
+        data = await self._client._request(
+            "GET", f"/sandboxes/{self.sandbox_id}/services"
+        )
+        return data.get("ports", [])
+
+    async def revoke_service(self, port: int) -> None:
+        """Stop exposing *port*.
+
+        Effective immediately, including for URLs that have not yet expired.
+        """
+        await self._client._request(
+            "DELETE", f"/sandboxes/{self.sandbox_id}/services/{port}"
+        )
 
     async def exec(
         self,

--- a/orchard_env/orchard_env/client/sandbox_client.py
+++ b/orchard_env/orchard_env/client/sandbox_client.py
@@ -32,6 +32,7 @@ import time
 import uuid
 from http.client import RemoteDisconnected
 from typing import TYPE_CHECKING, Union
+from urllib.parse import urlsplit
 
 import aiohttp
 import requests
@@ -39,6 +40,39 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 
 if TYPE_CHECKING:
     from orchard_env.client.process import AsyncContainerProcess, ContainerProcess
+
+
+def _origin(url: str) -> tuple[str, str, int]:
+    parsed = urlsplit(url)
+    return (
+        parsed.scheme.lower(),
+        (parsed.hostname or "").lower(),
+        parsed.port or (443 if parsed.scheme == "https" else 80),
+    )
+
+
+class _ScopedApiKeySession(requests.Session):
+    """Attach the management key only to the configured orchestrator origin."""
+
+    def __init__(self, base_url: str, api_key: str | None):
+        super().__init__()
+        self._management_origin = _origin(base_url)
+        self._api_key = api_key
+
+    def prepare_request(self, request):
+        prepared = super().prepare_request(request)
+        if self._api_key and _origin(prepared.url) == self._management_origin:
+            prepared.headers["X-API-Key"] = self._api_key
+        else:
+            prepared.headers.pop("X-API-Key", None)
+        return prepared
+
+    def rebuild_auth(self, prepared_request, response):
+        super().rebuild_auth(prepared_request, response)
+        if self._api_key and _origin(prepared_request.url) == self._management_origin:
+            prepared_request.headers["X-API-Key"] = self._api_key
+        else:
+            prepared_request.headers.pop("X-API-Key", None)
 
 
 # Global registry for tracking sandboxes to cleanup on exit
@@ -745,11 +779,9 @@ class SandboxClient:
             base_url or os.environ.get("SANDBOX_BASE_URL") or "http://localhost:8000"
         ).rstrip("/")
         self.timeout = timeout
-        self.session = requests.Session()
         # Use provided api_key or fall back to environment variable
         self.api_key = api_key or os.environ.get("SANDBOX_API_KEY")
-        if self.api_key:
-            self.session.headers["X-API-Key"] = self.api_key
+        self.session = _ScopedApiKeySession(self.base_url, self.api_key)
         # Use provided prefix or fall back to environment variable
         self.prefix = prefix or os.environ.get("SANDBOX_PREFIX")
         self.max_retries = 3

--- a/orchard_env/orchard_env/orchestrator/api.py
+++ b/orchard_env/orchard_env/orchestrator/api.py
@@ -1,8 +1,11 @@
 """FastAPI application and routes."""
 
 import asyncio
+import hmac
 import logging
+import time
 from contextlib import asynccontextmanager
+from urllib.parse import unquote_plus, urljoin, urlsplit
 
 import aiohttp
 from fastapi import (
@@ -28,9 +31,11 @@ from orchard_env.orchestrator.sandbox_manager import SandboxManager
 from orchard_env.orchestrator.service_proxy import (
     ServicePortError,
     ServiceProxyClient,
+    ServiceRequestTooLargeError,
     build_service_url,
     filter_request_headers,
     filter_response_headers,
+    filter_websocket_headers,
     validate_port,
 )
 from orchard_env.orchestrator.service_tokens import (
@@ -186,12 +191,131 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down Sandbox Orchestrator")
 
 
+def _configured_service_base_url() -> str:
+    """Return the validated wildcard origin template for service traffic."""
+    value = (settings.service_public_base_url or "").rstrip("/")
+    if not value:
+        raise HTTPException(
+            status_code=503,
+            detail="SERVICE_PUBLIC_BASE_URL is required for service endpoints",
+        )
+
+    if value.count("{subdomain}") != 1:
+        raise HTTPException(
+            status_code=503,
+            detail=("SERVICE_PUBLIC_BASE_URL must contain one {subdomain} placeholder"),
+        )
+
+    parsed = urlsplit(value.replace("{subdomain}", "probe"))
+    if (
+        not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail="SERVICE_PUBLIC_BASE_URL must be an origin without path or credentials",
+        )
+    if parsed.scheme != "https" and not (
+        settings.service_allow_insecure_http and parsed.scheme == "http"
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "SERVICE_PUBLIC_BASE_URL must use https "
+                "(or explicitly enable SERVICE_ALLOW_INSECURE_HTTP for development)"
+            ),
+        )
+    return value
+
+
+def _authority(value: str, scheme: str) -> tuple[str, int]:
+    """Normalise a Host header or URL authority for comparison."""
+    parsed = urlsplit(value if "://" in value else f"//{value}", scheme=scheme)
+    host = (parsed.hostname or "").lower()
+    port = parsed.port or (443 if scheme == "https" else 80)
+    return host, port
+
+
+class ServiceOriginIsolationMiddleware:
+    """Keep hostile service content off the management API origin.
+
+    The configured service origin serves only ``/s/...`` routes. Conversely,
+    capability routes are refused on every other origin. This prevents sandbox
+    HTML, cookies, or service workers from sharing an origin with management
+    endpoints.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if settings.enable_service_endpoints is not True or scope["type"] not in {
+            "http",
+            "websocket",
+        }:
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            service_url = _configured_service_base_url()
+        except HTTPException:
+            service_url = ""
+
+        path = scope.get("path", "")
+        is_service_path = path.startswith("/s/")
+        if not service_url and not is_service_path:
+            # Keep management endpoints reachable so they can return a clear
+            # configuration error instead of making the whole API disappear.
+            await self.app(scope, receive, send)
+            return
+        headers = {
+            key.decode("latin-1").lower(): value.decode("latin-1")
+            for key, value in scope.get("headers", [])
+        }
+        request_host = _authority(
+            headers.get("host", ""),
+            (
+                urlsplit(service_url.replace("{subdomain}", "probe")).scheme
+                if service_url
+                else "https"
+            ),
+        )
+        allowed = False
+        if service_url and is_service_path:
+            parts = path.split("/", 3)
+            token = parts[2] if len(parts) > 2 else ""
+            expected_url = urlsplit(build_service_url(service_url, token))
+            allowed = request_host == _authority(
+                expected_url.netloc, expected_url.scheme
+            )
+        elif service_url:
+            probe = urlsplit(service_url.replace("{subdomain}", "probe"))
+            suffix = (probe.hostname or "")[len("probe") :]
+            is_service_hostname = bool(suffix) and request_host[0].endswith(suffix)
+            allowed = not is_service_hostname
+        if allowed:
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 4404})
+            return
+
+        response = JSONResponse({"detail": "Not found"}, status_code=404)
+        await response(scope, receive, send)
+
+
 app = FastAPI(
     title="Sandbox Orchestrator",
     description="Azure AKS-based sandbox orchestration service",
     version="0.1.0",
     lifespan=lifespan,
 )
+app.add_middleware(ServiceOriginIsolationMiddleware)
 
 
 @app.middleware("http")
@@ -974,10 +1098,10 @@ async def exec_pty_ws(ws: WebSocket, sandbox_id: str) -> None:
 #     ANY /s/{token}/{path}      HTTP, including streaming responses
 #     WS  /s/{token}/{path}      WebSocket, frames forwarded verbatim
 #
-# The token rides in the path so that a client which appends its own suffix —
-# an OpenEnv EnvClient appending ``/ws`` — produces a working URL with no
-# special-casing, and so the credential never lands in a query string that
-# proxies habitually log.
+# The token rides in the path so a client which appends its own suffix — an
+# OpenEnv EnvClient appending ``/ws`` — produces a working URL. It is a bearer
+# credential and may appear in ingress request-target logs; operators must
+# redact ``/s/*`` and use short TTLs.
 #
 # Kubernetes note: the pod spec is unchanged. ``containerPort`` is
 # informational, so any process listening on 0.0.0.0 inside the pod is already
@@ -991,6 +1115,7 @@ class CreateServiceRequest(BaseModel):
     port: int = Field(..., description="Port the service listens on inside the sandbox")
     ttl_seconds: int | None = Field(
         default=None,
+        gt=0,
         description="Lifetime of the returned URL. Defaults to SERVICE_TOKEN_TTL_SECONDS.",
     )
     wait_ready: bool = Field(
@@ -1006,6 +1131,7 @@ class CreateServiceRequest(BaseModel):
     )
     ready_timeout: int = Field(
         default=60,
+        gt=0,
         description="Seconds to wait for the service when wait_ready is true",
     )
 
@@ -1027,7 +1153,7 @@ class ServiceListResponse(BaseModel):
 
 
 def _require_service_endpoints_enabled() -> None:
-    if not settings.enable_service_endpoints:
+    if settings.enable_service_endpoints is not True:
         raise HTTPException(
             status_code=404,
             detail=(
@@ -1035,43 +1161,17 @@ def _require_service_endpoints_enabled() -> None:
                 "ENABLE_SERVICE_ENDPOINTS=true on the orchestrator to enable them."
             ),
         )
-
-
-def _external_base_url(request: Request) -> str:
-    """External base URL used to build service URLs.
-
-    The capability token travels in this URL, so where the URL points matters:
-    a forged ``X-Forwarded-Host`` would hand the caller a link to an attacker's
-    domain and the token with it. Precedence is therefore:
-
-    1. ``SERVICE_PUBLIC_BASE_URL`` — explicit and always safe. Set this.
-    2. ``X-Forwarded-Proto``/``X-Forwarded-Host``, but only when
-       ``SERVICE_TRUST_FORWARDED_HEADERS`` is on, i.e. an operator has
-       confirmed a proxy overwrites them on every request.
-    3. The request's own scheme and host.
-    """
-    configured = settings.service_public_base_url
-    if configured:
-        return configured.rstrip("/")
-
-    scheme = request.url.scheme
-    host = request.headers.get("host") or request.url.netloc
-
-    if settings.service_trust_forwarded_headers:
-        forwarded_proto = request.headers.get("x-forwarded-proto")
-        forwarded_host = request.headers.get("x-forwarded-host")
-        if forwarded_proto:
-            scheme = forwarded_proto.split(",")[0].strip()
-        if forwarded_host:
-            host = forwarded_host.split(",")[0].strip()
-
-    return f"{scheme}://{host}"
+    _configured_service_base_url()
+    if not settings.service_token_secret:
+        raise HTTPException(
+            status_code=503,
+            detail="SERVICE_TOKEN_SECRET is required for service endpoints",
+        )
 
 
 @app.post("/sandboxes/{sandbox_id}/services", response_model=ServiceResponse)
 async def create_service(
     sandbox_id: str,
-    request: Request,
     body: CreateServiceRequest,
     api_key: str = Depends(verify_api_key),
 ):
@@ -1087,15 +1187,10 @@ async def create_service(
     if not sandbox:
         raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
 
-    try:
-        exposed = await sandbox_manager.expose_service(sandbox_id, port)
-    except ValueError as e:
-        raise HTTPException(status_code=409, detail=str(e))
-    if exposed is None:
-        raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
-
+    # Probe before changing exposure state. A failed readiness check must not
+    # reactivate a previously revoked URL or leave a half-created endpoint.
     if body.wait_ready:
-        pod_ip = await sandbox_manager.get_pod_ip(sandbox_id)
+        pod_ip = await sandbox_manager.get_current_pod_ip(sandbox_id)
         if not pod_ip:
             raise HTTPException(
                 status_code=503, detail=f"Pod IP not available for sandbox {sandbox_id}"
@@ -1114,13 +1209,21 @@ async def create_service(
                 )
             await asyncio.sleep(1)
 
-    token, expires_at = mint_token(sandbox_id, port, body.ttl_seconds)
+    try:
+        exposure = await sandbox_manager.expose_service(sandbox_id, port)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    if exposure is None:
+        raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
+    generation, _created = exposure
+
+    token, expires_at = mint_token(sandbox_id, port, generation, body.ttl_seconds)
     # The token is a bearer credential: return it, never log it.
     logger.info(f"Issued service endpoint for sandbox {sandbox_id} port {port}")
     return ServiceResponse(
         sandbox_id=sandbox_id,
         port=port,
-        url=build_service_url(_external_base_url(request), token),
+        url=build_service_url(_configured_service_base_url(), token),
         expires_at=expires_at,
     )
 
@@ -1130,13 +1233,10 @@ async def list_services(sandbox_id: str, api_key: str = Depends(verify_api_key))
     """List the ports a sandbox currently exposes."""
     _require_service_endpoints_enabled()
 
-    sandbox = await sandbox_manager.get_sandbox(sandbox_id)
-    if not sandbox:
+    ports = await sandbox_manager.list_services(sandbox_id)
+    if ports is None:
         raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
-
-    return ServiceListResponse(
-        sandbox_id=sandbox_id, ports=list(sandbox.exposed_ports or [])
-    )
+    return ServiceListResponse(sandbox_id=sandbox_id, ports=ports)
 
 
 @app.delete("/sandboxes/{sandbox_id}/services/{port}")
@@ -1158,7 +1258,7 @@ async def delete_service(
     return {"status": "revoked", "sandbox_id": sandbox_id, "port": port}
 
 
-async def _resolve_service_target(token: str) -> tuple[str, int, str]:
+async def _resolve_service_target(token: str) -> tuple[str, int, str, str, int]:
     """Validate a capability token and resolve it to a live pod.
 
     Returns ``(sandbox_id, port, pod_ip)``.
@@ -1168,7 +1268,7 @@ async def _resolve_service_target(token: str) -> tuple[str, int, str]:
     allowlist. That last check is what makes revocation immediate.
     """
     try:
-        sandbox_id, port = verify_token(token)
+        sandbox_id, port, generation, expires_at = verify_token(token)
     except ServiceTokenError as e:
         # Deliberately terse: do not tell a prober which part failed.
         raise HTTPException(status_code=403, detail=str(e))
@@ -1177,10 +1277,13 @@ async def _resolve_service_target(token: str) -> tuple[str, int, str]:
     if not sandbox:
         raise HTTPException(status_code=404, detail="Sandbox not found")
 
-    if port not in (sandbox.exposed_ports or []):
+    active_generation = await sandbox_manager.get_service_generation(sandbox_id, port)
+    if not active_generation or not hmac.compare_digest(active_generation, generation):
         raise HTTPException(status_code=403, detail="Port is not exposed")
 
-    pod_ip = await sandbox_manager.get_pod_ip(sandbox_id)
+    # Service capabilities cross a trust boundary; use an authoritative K8s
+    # read rather than a cache that may outlive a reused custom sandbox ID.
+    pod_ip = await sandbox_manager.get_current_pod_ip(sandbox_id)
     if not pod_ip:
         raise HTTPException(status_code=503, detail="Pod IP not available")
 
@@ -1190,7 +1293,224 @@ async def _resolve_service_target(token: str) -> tuple[str, int, str]:
         # POST /heartbeat itself.
         await sandbox_manager.heartbeat(sandbox_id)
 
-    return sandbox_id, port, pod_ip
+    return sandbox_id, port, pod_ip, generation, expires_at
+
+
+def _raw_service_path(scope: dict, token: str) -> str:
+    """Return the encoded suffix after ``/s/{token}`` from the ASGI scope."""
+    raw_path = scope.get("raw_path") or scope.get("path", "").encode("ascii")
+    prefix = f"/s/{token}".encode("ascii")
+    if raw_path == prefix:
+        return "/"
+    if not raw_path.startswith(prefix + b"/"):
+        raise HTTPException(status_code=400, detail="Malformed service path")
+    return raw_path[len(prefix) :].decode("ascii")
+
+
+def _raw_query_string(scope: dict) -> str:
+    return scope.get("query_string", b"").decode("ascii")
+
+
+def _safe_service_query_string(scope: dict) -> str:
+    """Drop a management ``api_key`` while preserving every other raw field."""
+    raw = _raw_query_string(scope)
+    if not raw:
+        return ""
+    management_keys = settings.get_api_keys_set()
+    kept: list[str] = []
+    for field in raw.split("&"):
+        key, separator, value = field.partition("=")
+        if (
+            unquote_plus(key).lower() == "api_key"
+            and separator
+            and unquote_plus(value) in management_keys
+        ):
+            continue
+        kept.append(field)
+    return "&".join(kept)
+
+
+def _safe_service_protocols(ws: WebSocket) -> tuple[str, ...]:
+    """Remove PTY management-auth subprotocols before forwarding."""
+    management_keys = settings.get_api_keys_set()
+    protocols: list[str] = []
+    for protocol in ws.headers.get("sec-websocket-protocol", "").split(","):
+        protocol = protocol.strip()
+        if not protocol:
+            continue
+        if (
+            protocol.startswith("api_key.")
+            and protocol[len("api_key.") :] in management_keys
+        ):
+            continue
+        protocols.append(protocol)
+    return tuple(protocols)
+
+
+def _rewrite_service_location(
+    location: str,
+    token: str,
+    raw_path: str,
+    pod_ip: str,
+    port: int,
+) -> str | None:
+    """Map a same-service redirect back beneath the capability URL.
+
+    Redirects to any other destination are refused so a client cannot carry
+    ambient credentials from the service endpoint to an attacker-controlled
+    origin.
+    """
+    upstream_current = f"http://{pod_ip}:{port}{raw_path}"
+    resolved = urlsplit(urljoin(upstream_current, location))
+    resolved_port = resolved.port or (443 if resolved.scheme == "https" else 80)
+    if (
+        resolved.scheme != "http"
+        or resolved.hostname != pod_ip
+        or resolved_port != port
+    ):
+        return None
+
+    service_base = build_service_url(_configured_service_base_url(), token)
+    rewritten = f"{service_base}{resolved.path or '/'}"
+    if resolved.query:
+        rewritten += f"?{resolved.query}"
+    if resolved.fragment:
+        rewritten += f"#{resolved.fragment}"
+    return rewritten
+
+
+def _service_response_headers(
+    raw_headers,
+    token: str,
+    raw_path: str,
+    pod_ip: str,
+    port: int,
+) -> list[tuple[str, str]]:
+    headers = filter_response_headers(raw_headers)
+    result: list[tuple[str, str]] = []
+    for key, value in headers:
+        if key.lower() != "location":
+            result.append((key, value))
+            continue
+        rewritten = _rewrite_service_location(value, token, raw_path, pod_ip, port)
+        if rewritten is None:
+            raise HTTPException(
+                status_code=502, detail="External service redirect blocked"
+            )
+        result.append((key, rewritten))
+    return result
+
+
+def _request_has_body(request: Request) -> bool:
+    length = request.headers.get("content-length")
+    if length:
+        try:
+            parsed_length = int(length)
+            if parsed_length < 0:
+                raise ValueError
+            if parsed_length > settings.service_proxy_max_request_bytes:
+                raise HTTPException(status_code=413, detail="Request body too large")
+            return parsed_length > 0
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid Content-Length")
+    return "transfer-encoding" in request.headers
+
+
+async def _bounded_request_body(request: Request):
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > settings.service_proxy_max_request_bytes:
+            raise ServiceRequestTooLargeError
+        yield chunk
+
+
+async def _maintain_service_session(
+    sandbox_id: str,
+    port: int,
+    generation: str,
+    expires_at: int,
+    close_session=None,
+) -> None:
+    """Refresh liveness and terminate when the capability stops authorizing."""
+    heartbeat_interval = max(
+        0.01, float(settings.service_active_heartbeat_interval_seconds)
+    )
+    authorization_interval = min(heartbeat_interval, 5.0)
+    next_heartbeat = 0.0
+    try:
+        while True:
+            if not await _service_session_authorized(
+                sandbox_id, port, generation, expires_at
+            ):
+                if close_session:
+                    await close_session()
+                return
+            if settings.service_traffic_refreshes_heartbeat:
+                now = asyncio.get_running_loop().time()
+                if now >= next_heartbeat:
+                    if not await sandbox_manager.heartbeat(sandbox_id):
+                        if close_session:
+                            await close_session()
+                        return
+                    next_heartbeat = now + heartbeat_interval
+            await asyncio.sleep(authorization_interval)
+    except asyncio.CancelledError:
+        return
+    except Exception as e:
+        # Authorization state is fail-closed. A transient Redis failure should
+        # terminate the capability session, not leave it running indefinitely.
+        logger.warning(f"Service authorization watchdog failed: {e}")
+        if close_session:
+            await close_session()
+
+
+async def _service_session_authorized(
+    sandbox_id: str, port: int, generation: str, expires_at: int
+) -> bool:
+    if time.time() > expires_at:
+        return False
+    active_generation = await sandbox_manager.get_service_generation(sandbox_id, port)
+    return bool(active_generation) and hmac.compare_digest(
+        active_generation, generation
+    )
+
+
+def _start_service_session_watchdog(
+    sandbox_id: str,
+    port: int,
+    generation: str,
+    expires_at: int,
+    close_session=None,
+) -> asyncio.Task:
+    return asyncio.create_task(
+        _maintain_service_session(
+            sandbox_id,
+            port,
+            generation,
+            expires_at,
+            close_session=close_session,
+        )
+    )
+
+
+async def _stop_task(task: asyncio.Task | None) -> None:
+    if not task:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@app.api_route(
+    "/s/{token}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+)
+async def proxy_service_http_root(token: str, request: Request):
+    """Proxy the exact service base URL without a slash redirect."""
+    return await proxy_service_http(token, "", request)
 
 
 @app.api_route(
@@ -1204,26 +1524,79 @@ async def proxy_service_http(token: str, path: str, request: Request):
     is the whole point: clients that cannot set headers can still connect.
     """
     _require_service_endpoints_enabled()
-    _sandbox_id, port, pod_ip = await _resolve_service_target(token)
+    sandbox_id, port, pod_ip, generation, expires_at = await _resolve_service_target(
+        token
+    )
 
-    body = await request.body()
-    try:
-        upstream = await service_proxy_client.request(
+    body = _bounded_request_body(request) if _request_has_body(request) else None
+    raw_path = _raw_service_path(request.scope, token)
+    upstream = None
+    authorization_lost = asyncio.Event()
+    request_task = asyncio.create_task(
+        service_proxy_client.request(
             method=request.method,
             pod_ip=pod_ip,
             port=port,
-            path=path,
-            query_string=request.url.query,
-            headers=filter_request_headers(dict(request.headers)),
-            body=body or None,
+            raw_path=raw_path,
+            raw_query_string=_safe_service_query_string(request.scope),
+            headers=filter_request_headers(request.headers),
+            body=body,
         )
+    )
+
+    async def _close_revoked_request() -> None:
+        authorization_lost.set()
+        if upstream is not None:
+            upstream.close()
+        elif not request_task.done():
+            request_task.cancel()
+
+    watchdog = _start_service_session_watchdog(
+        sandbox_id,
+        port,
+        generation,
+        expires_at,
+        close_session=_close_revoked_request,
+    )
+    try:
+        upstream = await request_task
+        if not await _service_session_authorized(
+            sandbox_id, port, generation, expires_at
+        ):
+            upstream.close()
+            await _stop_task(watchdog)
+            raise HTTPException(status_code=403, detail="Service capability expired")
+    except asyncio.CancelledError:
+        await _stop_task(watchdog)
+        if authorization_lost.is_set():
+            raise HTTPException(status_code=403, detail="Service capability expired")
+        raise
+    except ServiceRequestTooLargeError:
+        await _stop_task(watchdog)
+        raise HTTPException(status_code=413, detail="Request body too large")
     except TimeoutError:
+        await _stop_task(watchdog)
         raise HTTPException(status_code=504, detail="Service request timed out")
     except aiohttp.ClientError as e:
+        await _stop_task(watchdog)
+        if isinstance(e.__cause__, ServiceRequestTooLargeError):
+            raise HTTPException(status_code=413, detail="Request body too large")
         # The exception text carries the pod IP, which the caller has no
         # business seeing: keep it in the log, not the response.
         logger.warning(f"Service proxy upstream error on port {port}: {e}")
         raise HTTPException(status_code=502, detail="Service unreachable")
+    except Exception:
+        await _stop_task(watchdog)
+        raise
+
+    try:
+        response_headers = _service_response_headers(
+            upstream.raw_headers, token, raw_path, pod_ip, port
+        )
+    except HTTPException:
+        upstream.release()
+        await _stop_task(watchdog)
+        raise
 
     async def _stream():
         try:
@@ -1231,12 +1604,17 @@ async def proxy_service_http(token: str, path: str, request: Request):
                 yield chunk
         finally:
             upstream.release()
+            await _stop_task(watchdog)
 
-    return StreamingResponse(
+    response = StreamingResponse(
         _stream(),
         status_code=upstream.status,
-        headers=filter_response_headers(upstream.headers),
     )
+    response.raw_headers = [
+        (key.encode("latin-1"), value.encode("latin-1"))
+        for key, value in response_headers
+    ]
+    return response
 
 
 @app.websocket("/s/{token}/{path:path}")
@@ -1247,31 +1625,78 @@ async def proxy_service_ws(ws: WebSocket, token: str, path: str) -> None:
     code is propagated, so the orchestrator stays a dumb pipe — the same
     contract the PTY proxy already follows.
     """
-    if not settings.enable_service_endpoints:
+    if settings.enable_service_endpoints is not True:
         await ws.close(code=4404)
         return
 
     try:
-        _sandbox_id, port, pod_ip = await _resolve_service_target(token)
+        sandbox_id, port, pod_ip, generation, expires_at = (
+            await _resolve_service_target(token)
+        )
     except HTTPException as e:
         # Resolve before accepting so a rejection is a clean handshake failure
         # rather than an accepted socket that immediately dies.
         await ws.close(code=4403 if e.status_code == 403 else 4404)
         return
 
-    try:
-        upstream = await service_proxy_client.open_websocket(
+    offered_protocols = _safe_service_protocols(ws)
+    upstream = None
+    accepted = False
+    authorization_lost = asyncio.Event()
+    open_task = asyncio.create_task(
+        service_proxy_client.open_websocket(
             pod_ip=pod_ip,
             port=port,
-            path=path,
-            query_string=ws.url.query,
+            raw_path=_raw_service_path(ws.scope, token),
+            raw_query_string=_safe_service_query_string(ws.scope),
+            headers=filter_websocket_headers(ws.headers),
+            protocols=offered_protocols,
+            origin=ws.headers.get("origin"),
         )
+    )
+
+    async def _close_revoked_socket() -> None:
+        authorization_lost.set()
+        if accepted:
+            await ws.close(code=4403)
+        if upstream is not None:
+            await upstream.close()
+        elif not open_task.done():
+            open_task.cancel()
+
+    watchdog = _start_service_session_watchdog(
+        sandbox_id,
+        port,
+        generation,
+        expires_at,
+        close_session=_close_revoked_socket,
+    )
+    try:
+        upstream = await open_task
+    except asyncio.CancelledError:
+        await _stop_task(watchdog)
+        if authorization_lost.is_set():
+            await ws.close(code=4403)
+            return
+        raise
     except Exception as e:
+        await _stop_task(watchdog)
         logger.warning(f"Failed to open upstream WS on port {port}: {e}")
         await ws.close(code=4503)
         return
 
-    await ws.accept()
+    # The handshake may have taken long enough for the capability to expire or
+    # be revoked. Revalidate before accepting the downstream socket.
+    try:
+        await _resolve_service_target(token)
+    except HTTPException:
+        await upstream.close()
+        await _stop_task(watchdog)
+        await ws.close(code=4403)
+        return
+
+    await ws.accept(subprotocol=upstream.protocol)
+    accepted = True
 
     async def _client_to_service() -> None:
         try:
@@ -1314,14 +1739,24 @@ async def proxy_service_ws(ws: WebSocket, token: str, path: str) -> None:
             except Exception:
                 pass
 
-    to_service = asyncio.create_task(_client_to_service())
-    to_client = asyncio.create_task(_service_to_client())
-    _done, pending = await asyncio.wait(
-        {to_service, to_client}, return_when=asyncio.FIRST_COMPLETED
-    )
-    for task in pending:
-        task.cancel()
     try:
-        await upstream.close()
-    except Exception:
-        pass
+        to_service = asyncio.create_task(_client_to_service())
+        to_client = asyncio.create_task(_service_to_client())
+        _done, pending = await asyncio.wait(
+            {to_service, to_client}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+    finally:
+        try:
+            await upstream.close()
+        except Exception:
+            pass
+        await _stop_task(watchdog)
+
+
+@app.websocket("/s/{token}")
+async def proxy_service_ws_root(ws: WebSocket, token: str) -> None:
+    """Proxy the exact WebSocket service base URL."""
+    await proxy_service_ws(ws, token, "")

--- a/orchard_env/orchard_env/orchestrator/api.py
+++ b/orchard_env/orchard_env/orchestrator/api.py
@@ -14,7 +14,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field
 
@@ -25,6 +25,19 @@ from orchard_env.orchestrator.k8s_client import K8sClient
 from orchard_env.orchestrator.pod_watcher import PodWatcher
 from orchard_env.orchestrator.redis_job_store import RedisJobStore
 from orchard_env.orchestrator.sandbox_manager import SandboxManager
+from orchard_env.orchestrator.service_proxy import (
+    ServicePortError,
+    ServiceProxyClient,
+    build_service_url,
+    filter_request_headers,
+    filter_response_headers,
+    validate_port,
+)
+from orchard_env.orchestrator.service_tokens import (
+    ServiceTokenError,
+    mint_token,
+    verify_token,
+)
 from orchard_env.orchestrator.settings import settings
 from orchard_env.orchestrator.utils import (
     generate_request_id,
@@ -69,6 +82,7 @@ job_store: JobStore
 exec_manager: ExecManager
 pod_watcher: PodWatcher
 agent_client: AgentClient
+service_proxy_client: ServiceProxyClient
 cleanup_task: asyncio.Task | None = None
 
 
@@ -94,7 +108,7 @@ async def cleanup_loop():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
-    global k8s_client, sandbox_manager, job_store, exec_manager, pod_watcher, agent_client, cleanup_task
+    global k8s_client, sandbox_manager, job_store, exec_manager, pod_watcher, agent_client, service_proxy_client, cleanup_task
 
     # Setup logging
     setup_logging()
@@ -133,6 +147,13 @@ async def lifespan(app: FastAPI):
     # Agent client for direct pod communication (exec / file ops)
     agent_client = AgentClient()
 
+    # Proxy client for user services running inside sandboxes. Constructed
+    # unconditionally (it is inert until a request arrives) so the routes do
+    # not have to guard against a missing client.
+    service_proxy_client = ServiceProxyClient()
+    if settings.enable_service_endpoints:
+        logger.info("Sandbox service endpoints are enabled")
+
     # Start pod watcher (Watch/Informer pattern)
     pod_watcher = PodWatcher()
     await pod_watcher.start()
@@ -148,6 +169,9 @@ async def lifespan(app: FastAPI):
     # Cleanup
     if agent_client:
         await agent_client.close()
+
+    if service_proxy_client:
+        await service_proxy_client.close()
 
     if pod_watcher:
         await pod_watcher.stop()
@@ -927,5 +951,377 @@ async def exec_pty_ws(ws: WebSocket, sandbox_id: str) -> None:
         t.cancel()
     try:
         await agent_ws.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Sandbox service endpoints (HTTP + WebSocket proxy to a user service)
+# ---------------------------------------------------------------------------
+#
+# Exec and file I/O cover agents that *run commands*. A growing class of
+# workloads instead speaks a protocol to a long-running server inside the
+# sandbox: an OpenEnv environment server, an MCP server, a dev server, an
+# evaluation endpoint. Those need a reachable URL, not a shell.
+#
+# An operator opens a port explicitly:
+#
+#     POST /sandboxes/{id}/services      {"port": 8000}
+#       -> {"url": "https://host/s/<token>", "expires_at": ...}
+#
+# and traffic then flows through that URL:
+#
+#     ANY /s/{token}/{path}      HTTP, including streaming responses
+#     WS  /s/{token}/{path}      WebSocket, frames forwarded verbatim
+#
+# The token rides in the path so that a client which appends its own suffix —
+# an OpenEnv EnvClient appending ``/ws`` — produces a working URL with no
+# special-casing, and so the credential never lands in a query string that
+# proxies habitually log.
+#
+# Kubernetes note: the pod spec is unchanged. ``containerPort`` is
+# informational, so any process listening on 0.0.0.0 inside the pod is already
+# reachable at the pod IP. The gap this closes is reachability from *outside*
+# the cluster, not inside it.
+
+
+class CreateServiceRequest(BaseModel):
+    """Request to expose a service port running inside a sandbox."""
+
+    port: int = Field(..., description="Port the service listens on inside the sandbox")
+    ttl_seconds: int | None = Field(
+        default=None,
+        description="Lifetime of the returned URL. Defaults to SERVICE_TOKEN_TTL_SECONDS.",
+    )
+    wait_ready: bool = Field(
+        default=False,
+        description=(
+            "Block until the service answers health_path. Orchard's own "
+            "readiness only covers the in-pod agent, so a sandbox can be ready "
+            "while the service inside it is still starting."
+        ),
+    )
+    health_path: str = Field(
+        default="/health", description="Path polled when wait_ready is true"
+    )
+    ready_timeout: int = Field(
+        default=60,
+        description="Seconds to wait for the service when wait_ready is true",
+    )
+
+
+class ServiceResponse(BaseModel):
+    """An exposed service endpoint."""
+
+    sandbox_id: str
+    port: int
+    url: str
+    expires_at: float
+
+
+class ServiceListResponse(BaseModel):
+    """Ports currently exposed for a sandbox."""
+
+    sandbox_id: str
+    ports: list[int]
+
+
+def _require_service_endpoints_enabled() -> None:
+    if not settings.enable_service_endpoints:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Sandbox service endpoints are disabled. Set "
+                "ENABLE_SERVICE_ENDPOINTS=true on the orchestrator to enable them."
+            ),
+        )
+
+
+def _external_base_url(request: Request) -> str:
+    """External base URL used to build service URLs.
+
+    The capability token travels in this URL, so where the URL points matters:
+    a forged ``X-Forwarded-Host`` would hand the caller a link to an attacker's
+    domain and the token with it. Precedence is therefore:
+
+    1. ``SERVICE_PUBLIC_BASE_URL`` — explicit and always safe. Set this.
+    2. ``X-Forwarded-Proto``/``X-Forwarded-Host``, but only when
+       ``SERVICE_TRUST_FORWARDED_HEADERS`` is on, i.e. an operator has
+       confirmed a proxy overwrites them on every request.
+    3. The request's own scheme and host.
+    """
+    configured = settings.service_public_base_url
+    if configured:
+        return configured.rstrip("/")
+
+    scheme = request.url.scheme
+    host = request.headers.get("host") or request.url.netloc
+
+    if settings.service_trust_forwarded_headers:
+        forwarded_proto = request.headers.get("x-forwarded-proto")
+        forwarded_host = request.headers.get("x-forwarded-host")
+        if forwarded_proto:
+            scheme = forwarded_proto.split(",")[0].strip()
+        if forwarded_host:
+            host = forwarded_host.split(",")[0].strip()
+
+    return f"{scheme}://{host}"
+
+
+@app.post("/sandboxes/{sandbox_id}/services", response_model=ServiceResponse)
+async def create_service(
+    sandbox_id: str,
+    request: Request,
+    body: CreateServiceRequest,
+    api_key: str = Depends(verify_api_key),
+):
+    """Expose a port inside a sandbox and return a self-authenticating URL."""
+    _require_service_endpoints_enabled()
+
+    try:
+        port = validate_port(body.port)
+    except ServicePortError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    sandbox = await sandbox_manager.get_sandbox(sandbox_id)
+    if not sandbox:
+        raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
+
+    try:
+        exposed = await sandbox_manager.expose_service(sandbox_id, port)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    if exposed is None:
+        raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
+
+    if body.wait_ready:
+        pod_ip = await sandbox_manager.get_pod_ip(sandbox_id)
+        if not pod_ip:
+            raise HTTPException(
+                status_code=503, detail=f"Pod IP not available for sandbox {sandbox_id}"
+            )
+        deadline = asyncio.get_running_loop().time() + body.ready_timeout
+        while True:
+            if await service_proxy_client.probe(pod_ip, port, body.health_path):
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                raise HTTPException(
+                    status_code=408,
+                    detail=(
+                        f"Service on port {port} did not answer {body.health_path} "
+                        f"within {body.ready_timeout}s"
+                    ),
+                )
+            await asyncio.sleep(1)
+
+    token, expires_at = mint_token(sandbox_id, port, body.ttl_seconds)
+    # The token is a bearer credential: return it, never log it.
+    logger.info(f"Issued service endpoint for sandbox {sandbox_id} port {port}")
+    return ServiceResponse(
+        sandbox_id=sandbox_id,
+        port=port,
+        url=build_service_url(_external_base_url(request), token),
+        expires_at=expires_at,
+    )
+
+
+@app.get("/sandboxes/{sandbox_id}/services", response_model=ServiceListResponse)
+async def list_services(sandbox_id: str, api_key: str = Depends(verify_api_key)):
+    """List the ports a sandbox currently exposes."""
+    _require_service_endpoints_enabled()
+
+    sandbox = await sandbox_manager.get_sandbox(sandbox_id)
+    if not sandbox:
+        raise HTTPException(status_code=404, detail=f"Sandbox {sandbox_id} not found")
+
+    return ServiceListResponse(
+        sandbox_id=sandbox_id, ports=list(sandbox.exposed_ports or [])
+    )
+
+
+@app.delete("/sandboxes/{sandbox_id}/services/{port}")
+async def delete_service(
+    sandbox_id: str, port: int, api_key: str = Depends(verify_api_key)
+):
+    """Revoke a previously exposed port.
+
+    Takes effect immediately, including for tokens that have not yet expired.
+    """
+    _require_service_endpoints_enabled()
+
+    revoked = await sandbox_manager.revoke_service(sandbox_id, port)
+    if not revoked:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Port {port} is not exposed for sandbox {sandbox_id}",
+        )
+    return {"status": "revoked", "sandbox_id": sandbox_id, "port": port}
+
+
+async def _resolve_service_target(token: str) -> tuple[str, int, str]:
+    """Validate a capability token and resolve it to a live pod.
+
+    Returns ``(sandbox_id, port, pod_ip)``.
+
+    Every hop is re-checked on every request: the signature, the expiry, the
+    sandbox's continued existence, and the port's continued presence in the
+    allowlist. That last check is what makes revocation immediate.
+    """
+    try:
+        sandbox_id, port = verify_token(token)
+    except ServiceTokenError as e:
+        # Deliberately terse: do not tell a prober which part failed.
+        raise HTTPException(status_code=403, detail=str(e))
+
+    sandbox = await sandbox_manager.get_sandbox(sandbox_id)
+    if not sandbox:
+        raise HTTPException(status_code=404, detail="Sandbox not found")
+
+    if port not in (sandbox.exposed_ports or []):
+        raise HTTPException(status_code=403, detail="Port is not exposed")
+
+    pod_ip = await sandbox_manager.get_pod_ip(sandbox_id)
+    if not pod_ip:
+        raise HTTPException(status_code=503, detail="Pod IP not available")
+
+    if settings.service_traffic_refreshes_heartbeat:
+        # An actively used service should not be reaped by heartbeat cleanup
+        # just because the client drives it over the proxy instead of calling
+        # POST /heartbeat itself.
+        await sandbox_manager.heartbeat(sandbox_id)
+
+    return sandbox_id, port, pod_ip
+
+
+@app.api_route(
+    "/s/{token}/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+)
+async def proxy_service_http(token: str, path: str, request: Request):
+    """Proxy an HTTP request to a service inside a sandbox.
+
+    The URL is the credential, so no ``X-API-Key`` header is required — which
+    is the whole point: clients that cannot set headers can still connect.
+    """
+    _require_service_endpoints_enabled()
+    _sandbox_id, port, pod_ip = await _resolve_service_target(token)
+
+    body = await request.body()
+    try:
+        upstream = await service_proxy_client.request(
+            method=request.method,
+            pod_ip=pod_ip,
+            port=port,
+            path=path,
+            query_string=request.url.query,
+            headers=filter_request_headers(dict(request.headers)),
+            body=body or None,
+        )
+    except TimeoutError:
+        raise HTTPException(status_code=504, detail="Service request timed out")
+    except aiohttp.ClientError as e:
+        # The exception text carries the pod IP, which the caller has no
+        # business seeing: keep it in the log, not the response.
+        logger.warning(f"Service proxy upstream error on port {port}: {e}")
+        raise HTTPException(status_code=502, detail="Service unreachable")
+
+    async def _stream():
+        try:
+            async for chunk in upstream.content.iter_any():
+                yield chunk
+        finally:
+            upstream.release()
+
+    return StreamingResponse(
+        _stream(),
+        status_code=upstream.status,
+        headers=filter_response_headers(upstream.headers),
+    )
+
+
+@app.websocket("/s/{token}/{path:path}")
+async def proxy_service_ws(ws: WebSocket, token: str, path: str) -> None:
+    """Proxy a WebSocket to a service inside a sandbox.
+
+    Frames are forwarded verbatim in both directions and the upstream close
+    code is propagated, so the orchestrator stays a dumb pipe — the same
+    contract the PTY proxy already follows.
+    """
+    if not settings.enable_service_endpoints:
+        await ws.close(code=4404)
+        return
+
+    try:
+        _sandbox_id, port, pod_ip = await _resolve_service_target(token)
+    except HTTPException as e:
+        # Resolve before accepting so a rejection is a clean handshake failure
+        # rather than an accepted socket that immediately dies.
+        await ws.close(code=4403 if e.status_code == 403 else 4404)
+        return
+
+    try:
+        upstream = await service_proxy_client.open_websocket(
+            pod_ip=pod_ip,
+            port=port,
+            path=path,
+            query_string=ws.url.query,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to open upstream WS on port {port}: {e}")
+        await ws.close(code=4503)
+        return
+
+    await ws.accept()
+
+    async def _client_to_service() -> None:
+        try:
+            while True:
+                message = await ws.receive()
+                if message["type"] == "websocket.disconnect":
+                    break
+                if message.get("text") is not None:
+                    await upstream.send_str(message["text"])
+                elif message.get("bytes") is not None:
+                    await upstream.send_bytes(message["bytes"])
+        except WebSocketDisconnect:
+            pass
+        except Exception as e:
+            logger.warning(f"service ws client->service error: {e}")
+        finally:
+            await upstream.close()
+
+    async def _service_to_client() -> None:
+        try:
+            async for message in upstream:
+                if message.type == aiohttp.WSMsgType.TEXT:
+                    await ws.send_text(message.data)
+                elif message.type == aiohttp.WSMsgType.BINARY:
+                    await ws.send_bytes(message.data)
+                elif message.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    break
+        except Exception as e:
+            logger.warning(f"service ws service->client error: {e}")
+        finally:
+            try:
+                # Propagate the upstream close code so the client can tell a
+                # normal shutdown from a protocol error.
+                close_code = upstream.close_code or 1000
+                await ws.close(code=close_code)
+            except Exception:
+                pass
+
+    to_service = asyncio.create_task(_client_to_service())
+    to_client = asyncio.create_task(_service_to_client())
+    _done, pending = await asyncio.wait(
+        {to_service, to_client}, return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+    try:
+        await upstream.close()
     except Exception:
         pass

--- a/orchard_env/orchard_env/orchestrator/k8s_client.py
+++ b/orchard_env/orchard_env/orchestrator/k8s_client.py
@@ -490,6 +490,12 @@ class K8sClient:
             resources=resources,
             working_dir=working_dir,
             image_pull_policy="IfNotPresent",
+            # Override any AGENT_PORT baked into an arbitrary user image. The
+            # agent port is part of Orchard's trusted control plane and must
+            # match the port reserved from service exposure.
+            env=[
+                client.V1EnvVar(name="AGENT_PORT", value=str(agent_port)),
+            ],
             ports=[client.V1ContainerPort(container_port=agent_port, name="agent")],
             startup_probe=startup_probe,
             readiness_probe=readiness_probe,

--- a/orchard_env/orchard_env/orchestrator/main.py
+++ b/orchard_env/orchard_env/orchestrator/main.py
@@ -13,6 +13,14 @@ def main():
         host=settings.host,
         port=settings.port,
         log_config=None,  # We use our own logging setup
+        # Capability tokens are carried in /s/<token>/... request paths. The
+        # application logs service events without the token; the generic
+        # access logger would disclose it verbatim.
+        access_log=False,
+        # Application logs retain their configured level. Uvicorn's own INFO
+        # messages include WebSocket request targets, so keep that channel at
+        # warning; the root-handler filter also redacts capability paths.
+        log_level="warning",
         backlog=2048,  # Increase TCP accept queue for high concurrency
         # Keep idle HTTP/1.1 connections alive long enough that client-side
         # connection pools (requests.Session / aiohttp) don't race a

--- a/orchard_env/orchard_env/orchestrator/pod_watcher.py
+++ b/orchard_env/orchard_env/orchestrator/pod_watcher.py
@@ -279,6 +279,16 @@ class PodWatcher:
             event.set()  # Unblock any waiters
         self._failed_sandboxes.discard(sandbox_id)
 
+    def prepare_sandbox(self, sandbox_id: str):
+        """Clear stale state before creating a new pod with this sandbox ID."""
+        pod_name = f"sandbox-{sandbox_id}"
+        self._cache.pop(pod_name, None)
+        event = self._ready_events.pop(sandbox_id, None)
+        if event:
+            event.set()
+        self._failed_sandboxes.discard(sandbox_id)
+        self._deleted_sandboxes.discard(sandbox_id)
+
     async def _watch_loop(self):
         """Main watch loop with automatic reconnection."""
         while self._running:

--- a/orchard_env/orchard_env/orchestrator/redis_connection.py
+++ b/orchard_env/orchard_env/orchestrator/redis_connection.py
@@ -1,0 +1,32 @@
+"""Shared authenticated Redis client construction and safe logging."""
+
+from urllib.parse import urlsplit
+
+import redis.asyncio as redis
+
+from orchard_env.orchestrator.settings import settings
+
+
+def create_redis_client(redis_url: str) -> redis.Redis:
+    """Create a decoded-text Redis client, failing closed on missing auth."""
+    password = settings.redis_password
+    password_in_url = urlsplit(redis_url).password
+    if settings.redis_require_auth and not password and not password_in_url:
+        raise RuntimeError(
+            "Redis authentication is required. Set REDIS_PASSWORD or include "
+            "a password in REDIS_URL."
+        )
+
+    kwargs = {"encoding": "utf-8", "decode_responses": True}
+    if password:
+        kwargs["password"] = password
+    return redis.from_url(redis_url, **kwargs)
+
+
+def redis_log_target(redis_url: str) -> str:
+    """Return a credential-free endpoint description for logs."""
+    parsed = urlsplit(redis_url)
+    host = parsed.hostname or "<unknown>"
+    port = parsed.port or (6380 if parsed.scheme == "rediss" else 6379)
+    database = parsed.path or "/0"
+    return f"{parsed.scheme or 'redis'}://{host}:{port}{database}"

--- a/orchard_env/orchard_env/orchestrator/redis_job_store.py
+++ b/orchard_env/orchard_env/orchestrator/redis_job_store.py
@@ -8,6 +8,10 @@ import time
 import redis.asyncio as redis
 
 from orchard_env.orchestrator.job_store import Job, JobStatus
+from orchard_env.orchestrator.redis_connection import (
+    create_redis_client,
+    redis_log_target,
+)
 from orchard_env.orchestrator.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -38,11 +42,12 @@ class RedisJobStore:
     async def connect(self) -> None:
         """Connect to Redis."""
         if self._client is None:
-            self._client = redis.from_url(
-                self.redis_url, encoding="utf-8", decode_responses=True
-            )
+            self._client = create_redis_client(self.redis_url)
             await self._client.ping()
-            logger.info(f"RedisJobStore connected to Redis at {self.redis_url}")
+            logger.info(
+                f"RedisJobStore connected to Redis at "
+                f"{redis_log_target(self.redis_url)}"
+            )
 
     async def close(self) -> None:
         """Close Redis connection."""

--- a/orchard_env/orchard_env/orchestrator/redis_store.py
+++ b/orchard_env/orchard_env/orchestrator/redis_store.py
@@ -124,6 +124,65 @@ class RedisSandboxStore:
         logger.debug(f"Updated sandbox {sandbox_id}: {updates}")
         return True
 
+    async def mutate_sandbox(
+        self, sandbox_id: str, mutate, max_attempts: int = 5
+    ) -> dict | None:
+        """Apply a read-modify-write to a sandbox record atomically.
+
+        ``update_sandbox`` is fine for last-write-wins fields, but it loses
+        updates when two callers modify a *collection* concurrently: both read
+        the old value and the second write discards the first. This runs the
+        mutation inside a ``WATCH``/``MULTI`` transaction and retries if another
+        writer touched the record in between.
+
+        Args:
+            sandbox_id: Sandbox to modify.
+            mutate: Callable taking the current record dict and returning the
+                fields to write. Returning ``None`` aborts without writing.
+                It may be called more than once, so it must be side-effect free.
+            max_attempts: Retries before giving up on contention.
+
+        Returns:
+            The full updated record, or None if the sandbox does not exist or
+            the mutation aborted.
+
+        Raises:
+            TimeoutError: If the record stayed contended for every attempt.
+        """
+        client = await self._ensure_connected()
+        key = f"{self.SANDBOX_PREFIX}{sandbox_id}"
+
+        for _attempt in range(max_attempts):
+            async with client.pipeline() as pipe:
+                try:
+                    await pipe.watch(key)
+                    data = await pipe.get(key)
+                    if not data:
+                        await pipe.unwatch()
+                        return None
+
+                    sandbox_data = json.loads(data)
+                    updates = mutate(sandbox_data)
+                    if updates is None:
+                        await pipe.unwatch()
+                        return None
+
+                    sandbox_data.update(updates)
+                    pipe.multi()
+                    # Buffered until execute(): not awaited, unlike the
+                    # immediate-mode watch/get calls above.
+                    pipe.set(key, json.dumps(sandbox_data), ex=self.DEFAULT_TTL)
+                    await pipe.execute()
+                    return sandbox_data
+                except redis.WatchError:
+                    # Another replica wrote first; re-read and reapply.
+                    continue
+
+        raise TimeoutError(
+            f"Could not update sandbox {sandbox_id} after {max_attempts} attempts "
+            "due to contention"
+        )
+
     async def delete_sandbox(self, sandbox_id: str) -> bool:
         """Delete sandbox metadata.
 

--- a/orchard_env/orchard_env/orchestrator/redis_store.py
+++ b/orchard_env/orchard_env/orchestrator/redis_store.py
@@ -3,10 +3,15 @@
 import asyncio
 import json
 import logging
+import random
 import time
 
 import redis.asyncio as redis
 
+from orchard_env.orchestrator.redis_connection import (
+    create_redis_client,
+    redis_log_target,
+)
 from orchard_env.orchestrator.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -20,11 +25,13 @@ class RedisSandboxStore:
 
     Key schema:
     - sandbox:{sandbox_id} -> JSON of Sandbox dataclass
+    - sandbox:services:{sandbox_id} -> hash of port -> exposure generation
     - sandbox:lock:{sandbox_id} -> distributed lock for exec serialization
     - sandbox:all -> Set of all sandbox IDs
     """
 
     SANDBOX_PREFIX = "sandbox:"
+    SERVICE_PREFIX = "sandbox:services:"
     SANDBOX_SET_KEY = "sandbox:all"
     LOCK_PREFIX = "sandbox:lock:"
     DEFAULT_TTL = 3600 * 24  # 24 hours
@@ -42,12 +49,10 @@ class RedisSandboxStore:
     async def connect(self) -> None:
         """Connect to Redis."""
         if self._client is None:
-            self._client = redis.from_url(
-                self.redis_url, encoding="utf-8", decode_responses=True
-            )
+            self._client = create_redis_client(self.redis_url)
             # Test connection
             await self._client.ping()
-            logger.info(f"Connected to Redis at {self.redis_url}")
+            logger.info(f"Connected to Redis at {redis_log_target(self.redis_url)}")
 
     async def close(self) -> None:
         """Close Redis connection."""
@@ -98,42 +103,22 @@ class RedisSandboxStore:
         return None
 
     async def update_sandbox(self, sandbox_id: str, updates: dict) -> bool:
-        """Update sandbox metadata.
-
-        Args:
-            sandbox_id: Sandbox ID to update
-            updates: Dict of fields to update
-
-        Returns:
-            True if updated, False if sandbox not found
-        """
-        client = await self._ensure_connected()
-        key = f"{self.SANDBOX_PREFIX}{sandbox_id}"
-
-        # Get current data
-        data = await client.get(key)
-        if not data:
+        """Update sandbox metadata without clobbering a concurrent writer."""
+        updated = await self.mutate_sandbox(sandbox_id, lambda _record: updates)
+        if updated is None:
             return False
-
-        # Update fields
-        sandbox_data = json.loads(data)
-        sandbox_data.update(updates)
-
-        # Store back
-        await client.set(key, json.dumps(sandbox_data), ex=self.DEFAULT_TTL)
         logger.debug(f"Updated sandbox {sandbox_id}: {updates}")
         return True
 
     async def mutate_sandbox(
-        self, sandbox_id: str, mutate, max_attempts: int = 5
+        self, sandbox_id: str, mutate, max_attempts: int = 20
     ) -> dict | None:
         """Apply a read-modify-write to a sandbox record atomically.
 
-        ``update_sandbox`` is fine for last-write-wins fields, but it loses
-        updates when two callers modify a *collection* concurrently: both read
-        the old value and the second write discards the first. This runs the
-        mutation inside a ``WATCH``/``MULTI`` transaction and retries if another
-        writer touched the record in between.
+        The sandbox record is JSON, so even updates to different fields require
+        a compare-and-set: a GET/SET pair can restore stale values from another
+        field. This runs the mutation inside ``WATCH``/``MULTI`` and retries if
+        another writer commits first.
 
         Args:
             sandbox_id: Sandbox to modify.
@@ -176,12 +161,136 @@ class RedisSandboxStore:
                     return sandbox_data
                 except redis.WatchError:
                     # Another replica wrote first; re-read and reapply.
+                    await asyncio.sleep(
+                        random.uniform(0, min(0.05, 0.001 * 2**_attempt))
+                    )
                     continue
 
         raise TimeoutError(
             f"Could not update sandbox {sandbox_id} after {max_attempts} attempts "
             "due to contention"
         )
+
+    async def expose_service(
+        self,
+        sandbox_id: str,
+        port: int,
+        generation: str,
+        max_services: int,
+        max_attempts: int = 50,
+    ) -> tuple[str, bool] | None:
+        """Atomically expose a port without changing the sandbox record schema.
+
+        Returns:
+            ``(generation, created)``. Re-exposing an active port returns its
+            existing generation with ``created=False``. Returns None when the
+            sandbox no longer exists.
+        """
+        client = await self._ensure_connected()
+        sandbox_key = f"{self.SANDBOX_PREFIX}{sandbox_id}"
+        service_key = f"{self.SERVICE_PREFIX}{sandbox_id}"
+        port_field = str(port)
+
+        for _attempt in range(max_attempts):
+            async with client.pipeline() as pipe:
+                try:
+                    await pipe.watch(sandbox_key, service_key)
+                    sandbox_data_raw = await pipe.get(sandbox_key)
+                    if not sandbox_data_raw:
+                        await pipe.unwatch()
+                        return None
+                    sandbox_created_at = json.loads(sandbox_data_raw)["created_at"]
+
+                    existing = await pipe.hget(service_key, port_field)
+                    if existing:
+                        try:
+                            existing_data = json.loads(existing)
+                        except json.JSONDecodeError:
+                            existing_data = {}
+                        if existing_data.get("created_at") == sandbox_created_at:
+                            # Execute a no-state-change transaction so a
+                            # concurrent revoke or sandbox delete triggers
+                            # WatchError instead of returning a stale URL.
+                            pipe.multi()
+                            pipe.expire(service_key, self.DEFAULT_TTL)
+                            await pipe.execute()
+                            return existing_data["generation"], False
+
+                    if await pipe.hlen(service_key) >= max_services:
+                        # A stale entry for the same port will be overwritten,
+                        # not added, so it doesn't consume another slot.
+                        if not existing:
+                            await pipe.unwatch()
+                            raise ValueError(
+                                f"Sandbox {sandbox_id} already exposes "
+                                f"{max_services} ports "
+                                "(MAX_SERVICES_PER_SANDBOX)"
+                            )
+
+                    pipe.multi()
+                    pipe.hset(
+                        service_key,
+                        port_field,
+                        json.dumps(
+                            {
+                                "generation": generation,
+                                "created_at": sandbox_created_at,
+                            },
+                            separators=(",", ":"),
+                        ),
+                    )
+                    pipe.expire(service_key, self.DEFAULT_TTL)
+                    await pipe.execute()
+                    return generation, True
+                except redis.WatchError:
+                    await asyncio.sleep(
+                        random.uniform(0, min(0.05, 0.001 * 2**_attempt))
+                    )
+                    continue
+
+        raise TimeoutError(
+            f"Could not expose port {port} on sandbox {sandbox_id} after "
+            f"{max_attempts} attempts due to contention"
+        )
+
+    async def get_service_generation(
+        self, sandbox_id: str, port: int, sandbox_created_at: float
+    ) -> str | None:
+        """Return a generation only when it belongs to this sandbox instance."""
+        client = await self._ensure_connected()
+        value = await client.hget(f"{self.SERVICE_PREFIX}{sandbox_id}", str(port))
+        if not value:
+            return None
+        try:
+            data = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if data.get("created_at") != sandbox_created_at:
+            return None
+        return data.get("generation")
+
+    async def get_services(
+        self, sandbox_id: str, sandbox_created_at: float
+    ) -> dict[int, str]:
+        """Return exposed ports and generations for a sandbox."""
+        client = await self._ensure_connected()
+        values = await client.hgetall(f"{self.SERVICE_PREFIX}{sandbox_id}")
+        result: dict[int, str] = {}
+        for port, value in values.items():
+            try:
+                data = json.loads(value)
+            except json.JSONDecodeError:
+                continue
+            if data.get("created_at") != sandbox_created_at:
+                continue
+            result[int(port)] = data.get("generation", "")
+        return result
+
+    async def revoke_service(self, sandbox_id: str, port: int) -> bool:
+        """Revoke a port. A later expose receives a fresh generation."""
+        client = await self._ensure_connected()
+        deleted = await client.hdel(f"{self.SERVICE_PREFIX}{sandbox_id}", str(port))
+        return deleted > 0
 
     async def delete_sandbox(self, sandbox_id: str) -> bool:
         """Delete sandbox metadata.
@@ -201,9 +310,12 @@ class RedisSandboxStore:
         # Delete key
         deleted = await client.delete(key)
 
-        # Clean up lock
+        # Clean up lock and separately stored service state. Keeping services
+        # out of the JSON record makes rolling upgrades schema-compatible.
         lock_key = f"{self.LOCK_PREFIX}{sandbox_id}"
-        await client.delete(lock_key)
+        service_key = f"{self.SERVICE_PREFIX}{sandbox_id}"
+        pod_ip_key = f"{self.POD_IP_PREFIX}{sandbox_id}"
+        await client.delete(lock_key, service_key, pod_ip_key)
 
         if deleted:
             logger.debug(f"Deleted sandbox {sandbox_id} from Redis")
@@ -294,7 +406,9 @@ class RedisSandboxStore:
     POD_IP_PREFIX = "sandbox:ip:"
     POD_IP_TTL = 3600 * 24  # 24 hours — same as sandbox TTL
 
-    async def store_pod_ip(self, sandbox_id: str, pod_ip: str) -> None:
+    async def store_pod_ip(
+        self, sandbox_id: str, pod_ip: str, sandbox_created_at: float
+    ) -> None:
         """Cache a pod IP in Redis for cross-replica lookups.
 
         Uses a dedicated key (``sandbox:ip:<id>``) instead of embedding
@@ -303,10 +417,16 @@ class RedisSandboxStore:
         """
         client = await self._ensure_connected()
         key = f"{self.POD_IP_PREFIX}{sandbox_id}"
-        await client.set(key, pod_ip, ex=self.POD_IP_TTL)
+        await client.set(
+            key,
+            json.dumps({"ip": pod_ip, "created_at": sandbox_created_at}),
+            ex=self.POD_IP_TTL,
+        )
         logger.debug(f"Stored pod IP for {sandbox_id} in Redis: {pod_ip}")
 
-    async def get_pod_ip(self, sandbox_id: str) -> str | None:
+    async def get_pod_ip(
+        self, sandbox_id: str, sandbox_created_at: float
+    ) -> str | None:
         """Get cached pod IP from Redis.
 
         Returns:
@@ -314,7 +434,16 @@ class RedisSandboxStore:
         """
         client = await self._ensure_connected()
         key = f"{self.POD_IP_PREFIX}{sandbox_id}"
-        return await client.get(key)
+        value = await client.get(key)
+        if not value:
+            return None
+        try:
+            data = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if data.get("created_at") != sandbox_created_at:
+            return None
+        return data.get("ip")
 
     async def delete_pod_ip(self, sandbox_id: str) -> None:
         """Remove cached pod IP from Redis."""

--- a/orchard_env/orchard_env/orchestrator/sandbox_manager.py
+++ b/orchard_env/orchard_env/orchestrator/sandbox_manager.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import logging
+import secrets
 import time
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, field
 
 from orchard_env.orchestrator.k8s_client import K8sClient
 from orchard_env.orchestrator.settings import settings
@@ -26,10 +27,6 @@ class Sandbox:
     ready: bool = False
     creation_timeout: int = 3600  # Timeout requested during creation
     last_heartbeat: float | None = None  # Last heartbeat timestamp
-    # Ports explicitly opened through the service-endpoint proxy. Empty by
-    # default: a sandbox exposes nothing until an operator asks for it, and
-    # removing a port here revokes access immediately even for unexpired tokens.
-    exposed_ports: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for storage."""
@@ -37,13 +34,8 @@ class Sandbox:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Sandbox":
-        """Create from dictionary.
-
-        Unknown keys are ignored so that a replica running an older build can
-        still read a record written by a newer one during a rolling upgrade.
-        """
-        known = {f.name for f in fields(cls)}
-        return cls(**{key: value for key, value in data.items() if key in known})
+        """Create from dictionary."""
+        return cls(**data)
 
 
 class SandboxManager:
@@ -65,6 +57,7 @@ class SandboxManager:
         # In-memory fallback (used when Redis is disabled)
         self._sandboxes: dict[str, Sandbox] = {}
         self._locks: dict[str, asyncio.Lock] = {}
+        self._services: dict[str, dict[int, str]] = {}
         self._global_lock = asyncio.Lock()
 
     def set_pod_watcher(self, pod_watcher):
@@ -123,7 +116,13 @@ class SandboxManager:
 
         Returns None if pod IP is not available.
         """
-        # 1. PodWatcher local cache (fastest)
+        sandbox = await self.get_sandbox(sandbox_id)
+        if not sandbox:
+            return None
+
+        # 1. PodWatcher local cache (fastest). A new sandbox creation clears
+        # this entry before the pod is created, and deletion clears it before
+        # the ID can be reused.
         if self._pod_watcher:
             ip = self._pod_watcher.get_pod_ip(sandbox_id)
             if ip:
@@ -132,15 +131,27 @@ class SandboxManager:
         # 2. Redis cache (cross-replica, avoids K8s API call)
         redis_store = await self._get_redis_store()
         if redis_store:
-            ip = await redis_store.get_pod_ip(sandbox_id)
+            ip = await redis_store.get_pod_ip(sandbox_id, sandbox.created_at)
             if ip:
                 return ip
 
         # 3. K8s API fallback (slow path — write back to Redis)
         ip = await self._fetch_pod_ip_from_k8s(sandbox_id)
         if ip and redis_store:
-            await redis_store.store_pod_ip(sandbox_id, ip)
+            await redis_store.store_pod_ip(sandbox_id, ip, sandbox.created_at)
         return ip
+
+    async def get_current_pod_ip(self, sandbox_id: str) -> str | None:
+        """Resolve the current Kubernetes pod directly, bypassing every cache.
+
+        Service capabilities cross a trust boundary. A stale PodWatcher or
+        Redis entry must never route one to a prior pod after a custom sandbox
+        ID is reused, so service connection establishment pays one control-plane
+        read for an authoritative target.
+        """
+        if not await self.get_sandbox(sandbox_id):
+            return None
+        return await self._fetch_pod_ip_from_k8s(sandbox_id)
 
     async def _fetch_pod_ip_from_k8s(self, sandbox_id: str) -> str | None:
         """Query K8s API for pod IP (slow path)."""
@@ -173,7 +184,9 @@ class SandboxManager:
         if ip:
             redis_store = await self._get_redis_store()
             if redis_store:
-                await redis_store.store_pod_ip(sandbox_id, ip)
+                sandbox = await self.get_sandbox(sandbox_id)
+                if sandbox:
+                    await redis_store.store_pod_ip(sandbox_id, ip, sandbox.created_at)
 
     async def _get_redis_store(self):
         """Get Redis store, initializing if needed."""
@@ -225,6 +238,7 @@ class SandboxManager:
         else:
             async with self._global_lock:
                 self._sandboxes[sandbox.sandbox_id] = sandbox
+                self._services.pop(sandbox.sandbox_id, None)
                 if sandbox.sandbox_id not in self._locks:
                     self._locks[sandbox.sandbox_id] = asyncio.Lock()
 
@@ -252,6 +266,7 @@ class SandboxManager:
                     del self._sandboxes[sandbox_id]
                 if sandbox_id in self._locks:
                     del self._locks[sandbox_id]
+                self._services.pop(sandbox_id, None)
 
     async def _get_all_sandbox_ids(self) -> set:
         """Get all tracked sandbox IDs."""
@@ -320,6 +335,16 @@ class SandboxManager:
         pod_created = False
 
         try:
+            # A caller may intentionally reuse a custom sandbox ID after the
+            # previous pod was deleted. Clear every local/shared cache before
+            # creating the new pod so no stale target can be blessed as the new
+            # sandbox incarnation.
+            if self._pod_watcher:
+                self._pod_watcher.prepare_sandbox(sandbox_id)
+            redis_store = await self._get_redis_store()
+            if redis_store:
+                await redis_store.delete_pod_ip(sandbox_id)
+
             # Throttle concurrent creates to avoid overwhelming K8s API server
             # With 5 replicas × 20 concurrent creates = up to 100 K8s create calls
             async with self._create_semaphore:
@@ -570,13 +595,10 @@ class SandboxManager:
 
         # 1. Remove from store immediately — sandbox is "gone" for callers.
         await self._delete_sandbox_record(sandbox_id)
+        if self._pod_watcher:
+            self._pod_watcher.remove_sandbox(sandbox_id)
 
-        # 2. Remove pod IP cache from Redis.
-        redis_store = await self._get_redis_store()
-        if redis_store:
-            await redis_store.delete_pod_ip(sandbox_id)
-
-        # 3. Clean up K8s resources in the background (best-effort).
+        # 2. Clean up K8s resources in the background (best-effort).
         asyncio.create_task(
             self._background_delete_k8s_resources(
                 sandbox_id, pod_name, namespace, block_network
@@ -646,85 +668,72 @@ class SandboxManager:
         logger.debug(f"Heartbeat received for sandbox {sandbox_id}")
         return True
 
-    async def _mutate_sandbox(self, sandbox_id: str, mutate):
-        """Apply a read-modify-write to a sandbox record without losing updates.
+    async def expose_service(
+        self, sandbox_id: str, port: int
+    ) -> tuple[str, bool] | None:
+        """Expose a port and return ``(generation, created)``.
 
-        Concurrent callers modifying a collection field must not clobber each
-        other, so this uses an atomic Redis transaction when Redis is enabled
-        and the existing global lock in single-replica memory mode.
-
-        Args:
-            sandbox_id: Sandbox to modify.
-            mutate: Callable taking the record (as a dict) and returning the
-                fields to write, or None to abort. May be retried, so it must
-                be side-effect free.
-
-        Returns:
-            The updated record dict, or None if the sandbox is gone or the
-            mutation aborted.
+        Service state is stored separately from the sandbox JSON record. This
+        keeps rolling upgrades schema-compatible with replicas that do not know
+        about service endpoints yet. The opaque generation changes after a
+        revoke/re-expose cycle, permanently invalidating old URLs.
         """
+        generation = secrets.token_urlsafe(18)
         redis_store = await self._get_redis_store()
 
         if redis_store:
-            return await redis_store.mutate_sandbox(sandbox_id, mutate)
+            result = await redis_store.expose_service(
+                sandbox_id,
+                port,
+                generation,
+                settings.max_services_per_sandbox,
+            )
+            if result and result[1]:
+                logger.info(f"Exposed port {port} on sandbox {sandbox_id}")
+            return result
 
         async with self._global_lock:
-            sandbox = self._sandboxes.get(sandbox_id)
-            if not sandbox:
+            if sandbox_id not in self._sandboxes:
                 return None
-            record = sandbox.to_dict()
-            updates = mutate(record)
-            if updates is None:
-                return None
-            for key, value in updates.items():
-                setattr(sandbox, key, value)
-            return sandbox.to_dict()
-
-    async def expose_service(self, sandbox_id: str, port: int) -> list[int] | None:
-        """Add *port* to a sandbox's exposed-port allowlist.
-
-        Returns the updated allowlist, or None if the sandbox does not exist.
-        Idempotent: re-exposing an already-exposed port is not an error, so a
-        caller that retries after a network blip does not need to special-case
-        it.
-
-        Raises:
-            ValueError: If the sandbox already exposes the configured maximum
-                number of ports.
-        """
-        limit_exceeded = False
-
-        def _add(record: dict) -> dict | None:
-            nonlocal limit_exceeded
-            limit_exceeded = False
-            exposed = list(record.get("exposed_ports") or [])
-            if port in exposed:
-                # Already present: abort the write, the state is what we want.
-                return None
-            if len(exposed) >= settings.max_services_per_sandbox:
-                limit_exceeded = True
-                return None
-            exposed.append(port)
-            return {"exposed_ports": exposed}
-
-        updated = await self._mutate_sandbox(sandbox_id, _add)
-
-        if limit_exceeded:
-            raise ValueError(
-                f"Sandbox {sandbox_id} already exposes "
-                f"{settings.max_services_per_sandbox} ports "
-                "(MAX_SERVICES_PER_SANDBOX)"
-            )
-
-        if updated is None:
-            # Either the sandbox is gone, or the port was already exposed.
-            sandbox = await self.get_sandbox(sandbox_id)
-            if not sandbox:
-                return None
-            return list(sandbox.exposed_ports or [])
+            services = self._services.setdefault(sandbox_id, {})
+            existing = services.get(port)
+            if existing:
+                return existing, False
+            if len(services) >= settings.max_services_per_sandbox:
+                raise ValueError(
+                    f"Sandbox {sandbox_id} already exposes "
+                    f"{settings.max_services_per_sandbox} ports "
+                    "(MAX_SERVICES_PER_SANDBOX)"
+                )
+            services[port] = generation
 
         logger.info(f"Exposed port {port} on sandbox {sandbox_id}")
-        return list(updated.get("exposed_ports") or [])
+        return generation, True
+
+    async def get_service_generation(self, sandbox_id: str, port: int) -> str | None:
+        """Return the active generation for a port."""
+        sandbox = await self.get_sandbox(sandbox_id)
+        if not sandbox:
+            return None
+        redis_store = await self._get_redis_store()
+        if redis_store:
+            return await redis_store.get_service_generation(
+                sandbox_id, port, sandbox.created_at
+            )
+        async with self._global_lock:
+            return self._services.get(sandbox_id, {}).get(port)
+
+    async def list_services(self, sandbox_id: str) -> list[int] | None:
+        """Return exposed ports, or None if the sandbox does not exist."""
+        sandbox = await self.get_sandbox(sandbox_id)
+        if not sandbox:
+            return None
+        redis_store = await self._get_redis_store()
+        if redis_store:
+            services = await redis_store.get_services(sandbox_id, sandbox.created_at)
+            return sorted(services)
+        async with self._global_lock:
+            return sorted(self._services.get(sandbox_id, {}))
 
     async def revoke_service(self, sandbox_id: str, port: int) -> bool:
         """Remove *port* from a sandbox's allowlist.
@@ -737,19 +746,17 @@ class SandboxManager:
             True if the port was exposed and has been revoked.
         """
 
-        def _remove(record: dict) -> dict | None:
-            exposed = list(record.get("exposed_ports") or [])
-            if port not in exposed:
-                return None
-            exposed.remove(port)
-            return {"exposed_ports": exposed}
+        redis_store = await self._get_redis_store()
+        if redis_store:
+            revoked = await redis_store.revoke_service(sandbox_id, port)
+        else:
+            async with self._global_lock:
+                services = self._services.get(sandbox_id, {})
+                revoked = services.pop(port, None) is not None
 
-        updated = await self._mutate_sandbox(sandbox_id, _remove)
-        if updated is None:
-            return False
-
-        logger.info(f"Revoked port {port} on sandbox {sandbox_id}")
-        return True
+        if revoked:
+            logger.info(f"Revoked port {port} on sandbox {sandbox_id}")
+        return revoked
 
     async def cleanup_expired_sandboxes(self) -> int:
         """Clean up sandboxes that exceeded TTL, stuck in pending state, or missed heartbeats."""

--- a/orchard_env/orchard_env/orchestrator/sandbox_manager.py
+++ b/orchard_env/orchard_env/orchestrator/sandbox_manager.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 
 from orchard_env.orchestrator.k8s_client import K8sClient
 from orchard_env.orchestrator.settings import settings
@@ -26,6 +26,10 @@ class Sandbox:
     ready: bool = False
     creation_timeout: int = 3600  # Timeout requested during creation
     last_heartbeat: float | None = None  # Last heartbeat timestamp
+    # Ports explicitly opened through the service-endpoint proxy. Empty by
+    # default: a sandbox exposes nothing until an operator asks for it, and
+    # removing a port here revokes access immediately even for unexpired tokens.
+    exposed_ports: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for storage."""
@@ -33,8 +37,13 @@ class Sandbox:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Sandbox":
-        """Create from dictionary."""
-        return cls(**data)
+        """Create from dictionary.
+
+        Unknown keys are ignored so that a replica running an older build can
+        still read a record written by a newer one during a rolling upgrade.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{key: value for key, value in data.items() if key in known})
 
 
 class SandboxManager:
@@ -635,6 +644,111 @@ class SandboxManager:
         now = time.time()
         await self._update_sandbox(sandbox_id, {"last_heartbeat": now})
         logger.debug(f"Heartbeat received for sandbox {sandbox_id}")
+        return True
+
+    async def _mutate_sandbox(self, sandbox_id: str, mutate):
+        """Apply a read-modify-write to a sandbox record without losing updates.
+
+        Concurrent callers modifying a collection field must not clobber each
+        other, so this uses an atomic Redis transaction when Redis is enabled
+        and the existing global lock in single-replica memory mode.
+
+        Args:
+            sandbox_id: Sandbox to modify.
+            mutate: Callable taking the record (as a dict) and returning the
+                fields to write, or None to abort. May be retried, so it must
+                be side-effect free.
+
+        Returns:
+            The updated record dict, or None if the sandbox is gone or the
+            mutation aborted.
+        """
+        redis_store = await self._get_redis_store()
+
+        if redis_store:
+            return await redis_store.mutate_sandbox(sandbox_id, mutate)
+
+        async with self._global_lock:
+            sandbox = self._sandboxes.get(sandbox_id)
+            if not sandbox:
+                return None
+            record = sandbox.to_dict()
+            updates = mutate(record)
+            if updates is None:
+                return None
+            for key, value in updates.items():
+                setattr(sandbox, key, value)
+            return sandbox.to_dict()
+
+    async def expose_service(self, sandbox_id: str, port: int) -> list[int] | None:
+        """Add *port* to a sandbox's exposed-port allowlist.
+
+        Returns the updated allowlist, or None if the sandbox does not exist.
+        Idempotent: re-exposing an already-exposed port is not an error, so a
+        caller that retries after a network blip does not need to special-case
+        it.
+
+        Raises:
+            ValueError: If the sandbox already exposes the configured maximum
+                number of ports.
+        """
+        limit_exceeded = False
+
+        def _add(record: dict) -> dict | None:
+            nonlocal limit_exceeded
+            limit_exceeded = False
+            exposed = list(record.get("exposed_ports") or [])
+            if port in exposed:
+                # Already present: abort the write, the state is what we want.
+                return None
+            if len(exposed) >= settings.max_services_per_sandbox:
+                limit_exceeded = True
+                return None
+            exposed.append(port)
+            return {"exposed_ports": exposed}
+
+        updated = await self._mutate_sandbox(sandbox_id, _add)
+
+        if limit_exceeded:
+            raise ValueError(
+                f"Sandbox {sandbox_id} already exposes "
+                f"{settings.max_services_per_sandbox} ports "
+                "(MAX_SERVICES_PER_SANDBOX)"
+            )
+
+        if updated is None:
+            # Either the sandbox is gone, or the port was already exposed.
+            sandbox = await self.get_sandbox(sandbox_id)
+            if not sandbox:
+                return None
+            return list(sandbox.exposed_ports or [])
+
+        logger.info(f"Exposed port {port} on sandbox {sandbox_id}")
+        return list(updated.get("exposed_ports") or [])
+
+    async def revoke_service(self, sandbox_id: str, port: int) -> bool:
+        """Remove *port* from a sandbox's allowlist.
+
+        Revocation takes effect immediately, including for capability tokens
+        that have not yet expired, because the proxy re-checks the allowlist on
+        every request.
+
+        Returns:
+            True if the port was exposed and has been revoked.
+        """
+
+        def _remove(record: dict) -> dict | None:
+            exposed = list(record.get("exposed_ports") or [])
+            if port not in exposed:
+                return None
+            exposed.remove(port)
+            return {"exposed_ports": exposed}
+
+        updated = await self._mutate_sandbox(sandbox_id, _remove)
+        if updated is None:
+            return False
+
+        logger.info(f"Revoked port {port} on sandbox {sandbox_id}")
         return True
 
     async def cleanup_expired_sandboxes(self) -> int:

--- a/orchard_env/orchard_env/orchestrator/service_proxy.py
+++ b/orchard_env/orchard_env/orchestrator/service_proxy.py
@@ -1,35 +1,29 @@
-"""Proxying to a service running inside a sandbox.
+"""Proxy helpers for services running inside sandboxes.
 
-Orchard already reaches sandboxes on the fast path by talking straight to the
-pod IP: exec, file I/O, and the PTY WebSocket all bypass the Kubernetes API
-server. This module extends that to *user* services — an OpenEnv environment
-server, an MCP server, a dev server, an evaluation endpoint — so a caller
-outside the cluster can drive one over ordinary HTTP and WebSocket.
-
-Two details matter for correctness:
-
-* **Hop-by-hop headers must not be forwarded.** ``Connection``,
-  ``Transfer-Encoding``, ``Upgrade`` and friends describe a single hop, so
-  copying them onto the next one corrupts framing (RFC 9110 section 7.6.1).
-* **The port must be allowlisted per sandbox.** The proxy is a deliberate hole
-  in the sandbox boundary, so it only ever opens the ports an operator asked
-  for, and never the in-pod agent's own port.
-
-Nothing here imports Kubernetes: the pod IP arrives as a plain string, which
-keeps the module unit-testable without a cluster.
+The orchestrator already reaches pods directly for exec and file I/O. This
+module extends that fast path to user services while preserving the destination
+boundary: every connection remains pinned to the resolved pod IP and exposed
+port, including across redirects.
 """
 
+import asyncio
+import hashlib
 import logging
+from collections.abc import AsyncIterable, Iterable, Mapping
+from typing import Any
 from urllib.parse import urlencode
 
 import aiohttp
+from yarl import URL
 
 from orchard_env.orchestrator.settings import settings
 
 logger = logging.getLogger(__name__)
 
-# Headers that describe a single transport hop rather than the payload. They
-# are stripped in both directions (RFC 9110 section 7.6.1).
+HeaderPairs = list[tuple[str, str]]
+
+# RFC 9110 section 7.6.1. Fields named by Connection are removed dynamically in
+# addition to this fixed set.
 HOP_BY_HOP_HEADERS = frozenset(
     {
         "connection",
@@ -43,28 +37,52 @@ HOP_BY_HOP_HEADERS = frozenset(
     }
 )
 
-# Never forwarded upstream: they describe the client's connection to the
-# orchestrator, and aiohttp recomputes them for the upstream request.
-_REQUEST_DROP_HEADERS = frozenset({"host", "content-length"})
+# Never forward ambient management/browser credentials into hostile sandbox
+# code. The capability URL already authenticates access to the service.
+_REQUEST_DROP_HEADERS = frozenset(
+    {
+        "authorization",
+        "content-length",
+        "cookie",
+        "host",
+        "x-api-key",
+    }
+)
 
-# Responses are forwarded byte for byte (the client session is created with
-# `auto_decompress=False`), so `Content-Encoding` and `Content-Length` still
-# describe the payload accurately and MUST be preserved — stripping
-# `Content-Encoding` while passing compressed bytes through hands the client
-# undecodable data. Only hop-by-hop headers are removed.
-_RESPONSE_DROP_HEADERS: frozenset[str] = frozenset()
+# A sandbox service must not write cookies for the shared service origin or
+# broaden a service worker beyond its token-scoped path.
+_RESPONSE_DROP_HEADERS = frozenset(
+    {
+        "service-worker-allowed",
+        "set-cookie",
+        "set-cookie2",
+    }
+)
+
+# WebSocket metadata that is useful to the service and safe to forward.
+_WEBSOCKET_HEADER_ALLOWLIST = frozenset(
+    {
+        "accept-language",
+        "user-agent",
+        "x-request-id",
+    }
+)
 
 
 class ServicePortError(ValueError):
     """Raised when a requested port may not be exposed."""
 
 
-def validate_port(port: int) -> int:
-    """Return *port* if it may be exposed, else raise :class:`ServicePortError`.
+class ServiceDestinationError(aiohttp.ClientError):
+    """Raised when a redirect attempts to leave the pinned pod and port."""
 
-    The in-pod agent's port is always refused: exposing it would hand the
-    caller unauthenticated exec and file access inside the sandbox.
-    """
+
+class ServiceRequestTooLargeError(Exception):
+    """Raised while streaming a request body beyond the configured limit."""
+
+
+def validate_port(port: int) -> int:
+    """Return *port* if it may be exposed, otherwise raise."""
     if not isinstance(port, int) or isinstance(port, bool):
         raise ServicePortError("Port must be an integer")
     if not 1 <= port <= 65535:
@@ -95,62 +113,148 @@ def _reserved_ports() -> set[int]:
     return ports
 
 
-def filter_request_headers(headers: dict) -> dict:
-    """Strip hop-by-hop and connection-specific headers from a client request."""
-    return {
-        key: value
-        for key, value in headers.items()
-        if key.lower() not in HOP_BY_HOP_HEADERS
-        and key.lower() not in _REQUEST_DROP_HEADERS
-    }
+def _normalise_header_pairs(headers: Any) -> HeaderPairs:
+    """Return headers as a duplicate-preserving list of text pairs."""
+
+    def text(value: Any) -> str:
+        return value.decode("latin-1") if isinstance(value, bytes) else str(value)
+
+    raw = getattr(headers, "raw", None)
+    if raw is not None:
+        return [(text(key), text(value)) for key, value in raw]
+    if isinstance(headers, Mapping):
+        return [(text(key), text(value)) for key, value in headers.items()]
+    return [(text(key), text(value)) for key, value in headers]
 
 
-def filter_response_headers(headers) -> dict:
-    """Strip hop-by-hop headers from an upstream response.
+def _connection_named_headers(pairs: Iterable[tuple[str, str]]) -> set[str]:
+    """Return field names listed by any Connection header."""
+    named: set[str] = set()
+    for key, value in pairs:
+        if key.lower() == "connection":
+            named.update(
+                part.strip().lower() for part in value.split(",") if part.strip()
+            )
+    return named
 
-    Content headers are deliberately kept: the body is relayed unmodified, so
-    ``Content-Encoding`` and ``Content-Length`` still describe it correctly.
+
+def filter_request_headers(headers: Any) -> HeaderPairs:
+    """Filter client headers before they reach hostile sandbox code.
+
+    Preserves duplicate ordinary headers, strips hop-by-hop fields (including
+    fields named dynamically by ``Connection``), and removes ambient
+    management/browser credentials.
     """
-    return {
-        key: value
-        for key, value in headers.items()
-        if key.lower() not in HOP_BY_HOP_HEADERS
-        and key.lower() not in _RESPONSE_DROP_HEADERS
-    }
+    pairs = _normalise_header_pairs(headers)
+    dropped = HOP_BY_HOP_HEADERS | _REQUEST_DROP_HEADERS
+    dropped = dropped | _connection_named_headers(pairs)
+    return [(key, value) for key, value in pairs if key.lower() not in dropped]
+
+
+def filter_response_headers(headers: Any) -> HeaderPairs:
+    """Filter upstream headers while preserving duplicates and content metadata.
+
+    The body is relayed byte-for-byte with decompression disabled, so
+    ``Content-Encoding`` and ``Content-Length`` remain accurate.
+    """
+    pairs = _normalise_header_pairs(headers)
+    dropped = HOP_BY_HOP_HEADERS | _RESPONSE_DROP_HEADERS
+    dropped = dropped | _connection_named_headers(pairs)
+    return [(key, value) for key, value in pairs if key.lower() not in dropped]
+
+
+def filter_websocket_headers(headers: Any) -> HeaderPairs:
+    """Return the safe subset of client WebSocket handshake headers."""
+    pairs = _normalise_header_pairs(headers)
+    return [
+        (key, value)
+        for key, value in pairs
+        if key.lower() in _WEBSOCKET_HEADER_ALLOWLIST
+    ]
 
 
 def build_upstream_url(
-    pod_ip: str, port: int, path: str, query_string: str = "", scheme: str = "http"
-) -> str:
-    """Build the in-cluster URL for a proxied request.
-
-    ``path`` is the remainder after the proxy prefix and may be empty. Query
-    strings are passed through verbatim so upstream parsing is unchanged.
-    """
-    suffix = path if path.startswith("/") else f"/{path}"
-    url = f"{scheme}://{pod_ip}:{port}{suffix}"
-    if query_string:
-        url = f"{url}?{query_string}"
-    return url
+    pod_ip: str,
+    port: int,
+    raw_path: str,
+    raw_query_string: str = "",
+    scheme: str = "http",
+) -> URL:
+    """Build an encoded URL without reinterpreting escaped path delimiters."""
+    path = raw_path if raw_path.startswith("/") else f"/{raw_path}"
+    return URL.build(
+        scheme=scheme,
+        host=pod_ip,
+        port=port,
+        path=path or "/",
+        query_string=raw_query_string,
+        encoded=True,
+    )
 
 
 def build_service_url(base_url: str, token: str) -> str:
-    """Build the externally reachable base URL for a service endpoint.
+    """Build a per-capability origin from a wildcard URL template."""
+    subdomain = hashlib.sha256(token.encode()).hexdigest()[:32]
+    origin = base_url.replace("{subdomain}", subdomain).rstrip("/")
+    return f"{origin}/s/{token}"
 
-    The token rides in the path rather than the query string so that clients
-    which append their own path — an OpenEnv ``EnvClient`` appending ``/ws`` —
-    produce a working URL without special-casing.
-    """
-    return f"{base_url.rstrip('/')}/s/{token}"
+
+class _PinnedTCPConnector(aiohttp.TCPConnector):
+    """Reject redirects that attempt to leave one pod IP and port."""
+
+    def __init__(self, host: str, port: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._pinned_host = host
+        self._pinned_port = port
+
+    async def _create_connection(self, req, *args, **kwargs):
+        request_port = req.url.port or (
+            443 if req.url.scheme in {"https", "wss"} else 80
+        )
+        if req.url.host != self._pinned_host or request_port != self._pinned_port:
+            raise ServiceDestinationError(
+                "WebSocket redirect attempted to leave the exposed sandbox service"
+            )
+        return await super()._create_connection(req, *args, **kwargs)
+
+
+class ServiceWebSocket:
+    """A WebSocket response that also owns its one-connection session."""
+
+    def __init__(
+        self,
+        websocket: aiohttp.ClientWebSocketResponse,
+        session: aiohttp.ClientSession,
+    ) -> None:
+        self._websocket = websocket
+        self._session = session
+
+    @property
+    def protocol(self) -> str | None:
+        return self._websocket.protocol
+
+    @property
+    def close_code(self) -> int | None:
+        return self._websocket.close_code
+
+    def __aiter__(self):
+        return self._websocket.__aiter__()
+
+    async def send_str(self, value: str) -> None:
+        await self._websocket.send_str(value)
+
+    async def send_bytes(self, value: bytes) -> None:
+        await self._websocket.send_bytes(value)
+
+    async def close(self) -> None:
+        try:
+            await self._websocket.close()
+        finally:
+            await self._session.close()
 
 
 class ServiceProxyClient:
-    """Forwards HTTP and WebSocket traffic to a service inside a sandbox.
-
-    Holds one pooled :class:`aiohttp.ClientSession`, mirroring
-    :class:`~orchard_env.orchestrator.agent_client.AgentClient`, so connections
-    to the same pod are reused across requests.
-    """
+    """Forwards HTTP and WebSocket traffic to sandbox services."""
 
     def __init__(self) -> None:
         self._session: aiohttp.ClientSession | None = None
@@ -160,16 +264,15 @@ class ServiceProxyClient:
             connector = aiohttp.TCPConnector(
                 limit=settings.service_proxy_pool_size,
                 limit_per_host=settings.service_proxy_pool_limit_per_host,
-                ttl_dns_cache=0,  # pod IPs are ephemeral; never cache DNS
+                ttl_dns_cache=0,
             )
             self._session = aiohttp.ClientSession(
                 connector=connector,
-                # Per-request timeouts are applied at the call site; a service
-                # may legitimately stream for a long time.
+                cookie_jar=aiohttp.DummyCookieJar(),
                 timeout=aiohttp.ClientTimeout(
                     total=None, connect=settings.service_proxy_connect_timeout
                 ),
-                auto_decompress=False,  # pass the upstream encoding through untouched
+                auto_decompress=False,
             )
         return self._session
 
@@ -178,20 +281,17 @@ class ServiceProxyClient:
         method: str,
         pod_ip: str,
         port: int,
-        path: str,
-        query_string: str = "",
-        headers: dict | None = None,
-        body: bytes | None = None,
+        raw_path: str,
+        raw_query_string: str = "",
+        headers: HeaderPairs | None = None,
+        body: AsyncIterable[bytes] | bytes | None = None,
         timeout: float | None = None,
     ) -> aiohttp.ClientResponse:
-        """Send a proxied HTTP request and return the streaming response.
-
-        The response is returned before its body is read so large or streaming
-        payloads are not buffered in the orchestrator. The caller owns the
-        response and must release it.
-        """
+        """Send an HTTP request without following redirects."""
         session = await self._get_session()
-        url = build_upstream_url(pod_ip, port, path, query_string)
+        url = build_upstream_url(
+            pod_ip, port, raw_path, raw_query_string=raw_query_string
+        )
         request_timeout = aiohttp.ClientTimeout(
             total=(
                 timeout
@@ -203,53 +303,83 @@ class ServiceProxyClient:
         return await session.request(
             method,
             url,
-            headers=headers or {},
+            headers=headers or (),
             data=body,
             timeout=request_timeout,
-            allow_redirects=False,  # redirects are the caller's to interpret
+            allow_redirects=False,
         )
 
     async def open_websocket(
         self,
         pod_ip: str,
         port: int,
-        path: str,
-        query_string: str = "",
-        headers: dict | None = None,
+        raw_path: str,
+        raw_query_string: str = "",
+        headers: HeaderPairs | None = None,
         protocols: tuple[str, ...] = (),
-    ) -> aiohttp.ClientWebSocketResponse:
-        """Open a WebSocket to a service inside the sandbox.
+        origin: str | None = None,
+    ) -> ServiceWebSocket:
+        """Open a destination-pinned WebSocket.
 
-        The caller owns the returned socket and must close it. ``heartbeat`` is
-        left unset: ping/pong is forwarded end to end so the real client's
-        keepalive reaches the real server.
+        aiohttp follows WebSocket redirects by default. A connector dedicated to
+        this socket rejects any redirected host or port before a connection is
+        made, while still permitting a same-service path redirect.
         """
-        session = await self._get_session()
-        url = build_upstream_url(pod_ip, port, path, query_string, scheme="ws")
-        return await session.ws_connect(
-            url,
-            headers=headers or {},
-            protocols=protocols,
-            max_msg_size=settings.service_proxy_max_message_bytes,
-            autoping=True,
+        connector = _PinnedTCPConnector(
+            pod_ip,
+            port,
+            limit=1,
+            ttl_dns_cache=0,
         )
+        session = aiohttp.ClientSession(
+            connector=connector,
+            cookie_jar=aiohttp.DummyCookieJar(),
+            timeout=aiohttp.ClientTimeout(
+                total=None, connect=settings.service_proxy_connect_timeout
+            ),
+        )
+        url = build_upstream_url(
+            pod_ip,
+            port,
+            raw_path,
+            raw_query_string=raw_query_string,
+            scheme="ws",
+        )
+        try:
+            websocket = await asyncio.wait_for(
+                session.ws_connect(
+                    url,
+                    headers=headers or (),
+                    protocols=protocols,
+                    origin=origin,
+                    max_msg_size=settings.service_proxy_max_message_bytes,
+                    autoping=True,
+                ),
+                timeout=settings.service_proxy_handshake_timeout_seconds,
+            )
+        except BaseException:
+            await session.close()
+            raise
+        return ServiceWebSocket(websocket, session)
 
     async def probe(
         self, pod_ip: str, port: int, path: str, timeout: float = 5.0
     ) -> bool:
-        """Return True when the service answers *path* with a 2xx status."""
+        """Return True only for a direct 2xx response; never follow redirects."""
         session = await self._get_session()
         url = build_upstream_url(pod_ip, port, path)
         try:
             async with session.get(
-                url, timeout=aiohttp.ClientTimeout(total=timeout, connect=timeout)
+                url,
+                timeout=aiohttp.ClientTimeout(total=timeout, connect=timeout),
+                allow_redirects=False,
             ) as response:
                 return 200 <= response.status < 300
         except Exception:
             return False
 
     async def close(self) -> None:
-        """Close the pooled session."""
+        """Close the pooled HTTP session."""
         if self._session and not self._session.closed:
             await self._session.close()
 

--- a/orchard_env/orchard_env/orchestrator/service_proxy.py
+++ b/orchard_env/orchard_env/orchestrator/service_proxy.py
@@ -1,0 +1,259 @@
+"""Proxying to a service running inside a sandbox.
+
+Orchard already reaches sandboxes on the fast path by talking straight to the
+pod IP: exec, file I/O, and the PTY WebSocket all bypass the Kubernetes API
+server. This module extends that to *user* services — an OpenEnv environment
+server, an MCP server, a dev server, an evaluation endpoint — so a caller
+outside the cluster can drive one over ordinary HTTP and WebSocket.
+
+Two details matter for correctness:
+
+* **Hop-by-hop headers must not be forwarded.** ``Connection``,
+  ``Transfer-Encoding``, ``Upgrade`` and friends describe a single hop, so
+  copying them onto the next one corrupts framing (RFC 9110 section 7.6.1).
+* **The port must be allowlisted per sandbox.** The proxy is a deliberate hole
+  in the sandbox boundary, so it only ever opens the ports an operator asked
+  for, and never the in-pod agent's own port.
+
+Nothing here imports Kubernetes: the pod IP arrives as a plain string, which
+keeps the module unit-testable without a cluster.
+"""
+
+import logging
+from urllib.parse import urlencode
+
+import aiohttp
+
+from orchard_env.orchestrator.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Headers that describe a single transport hop rather than the payload. They
+# are stripped in both directions (RFC 9110 section 7.6.1).
+HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+# Never forwarded upstream: they describe the client's connection to the
+# orchestrator, and aiohttp recomputes them for the upstream request.
+_REQUEST_DROP_HEADERS = frozenset({"host", "content-length"})
+
+# Responses are forwarded byte for byte (the client session is created with
+# `auto_decompress=False`), so `Content-Encoding` and `Content-Length` still
+# describe the payload accurately and MUST be preserved — stripping
+# `Content-Encoding` while passing compressed bytes through hands the client
+# undecodable data. Only hop-by-hop headers are removed.
+_RESPONSE_DROP_HEADERS: frozenset[str] = frozenset()
+
+
+class ServicePortError(ValueError):
+    """Raised when a requested port may not be exposed."""
+
+
+def validate_port(port: int) -> int:
+    """Return *port* if it may be exposed, else raise :class:`ServicePortError`.
+
+    The in-pod agent's port is always refused: exposing it would hand the
+    caller unauthenticated exec and file access inside the sandbox.
+    """
+    if not isinstance(port, int) or isinstance(port, bool):
+        raise ServicePortError("Port must be an integer")
+    if not 1 <= port <= 65535:
+        raise ServicePortError(f"Port {port} is outside the valid range 1-65535")
+    if port == settings.agent_port:
+        raise ServicePortError(
+            f"Port {port} is reserved for the in-pod sandbox agent and cannot "
+            "be exposed"
+        )
+    if port in _reserved_ports():
+        raise ServicePortError(f"Port {port} is reserved and cannot be exposed")
+    return port
+
+
+def _reserved_ports() -> set[int]:
+    """Parse the operator-configured reserved port list."""
+    raw = settings.service_reserved_ports
+    if not raw:
+        return set()
+    ports: set[int] = set()
+    for chunk in str(raw).replace(",", " ").split():
+        try:
+            ports.add(int(chunk))
+        except ValueError:
+            logger.warning(
+                "Ignoring non-integer entry in SERVICE_RESERVED_PORTS: %r", chunk
+            )
+    return ports
+
+
+def filter_request_headers(headers: dict) -> dict:
+    """Strip hop-by-hop and connection-specific headers from a client request."""
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in HOP_BY_HOP_HEADERS
+        and key.lower() not in _REQUEST_DROP_HEADERS
+    }
+
+
+def filter_response_headers(headers) -> dict:
+    """Strip hop-by-hop headers from an upstream response.
+
+    Content headers are deliberately kept: the body is relayed unmodified, so
+    ``Content-Encoding`` and ``Content-Length`` still describe it correctly.
+    """
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in HOP_BY_HOP_HEADERS
+        and key.lower() not in _RESPONSE_DROP_HEADERS
+    }
+
+
+def build_upstream_url(
+    pod_ip: str, port: int, path: str, query_string: str = "", scheme: str = "http"
+) -> str:
+    """Build the in-cluster URL for a proxied request.
+
+    ``path`` is the remainder after the proxy prefix and may be empty. Query
+    strings are passed through verbatim so upstream parsing is unchanged.
+    """
+    suffix = path if path.startswith("/") else f"/{path}"
+    url = f"{scheme}://{pod_ip}:{port}{suffix}"
+    if query_string:
+        url = f"{url}?{query_string}"
+    return url
+
+
+def build_service_url(base_url: str, token: str) -> str:
+    """Build the externally reachable base URL for a service endpoint.
+
+    The token rides in the path rather than the query string so that clients
+    which append their own path — an OpenEnv ``EnvClient`` appending ``/ws`` —
+    produce a working URL without special-casing.
+    """
+    return f"{base_url.rstrip('/')}/s/{token}"
+
+
+class ServiceProxyClient:
+    """Forwards HTTP and WebSocket traffic to a service inside a sandbox.
+
+    Holds one pooled :class:`aiohttp.ClientSession`, mirroring
+    :class:`~orchard_env.orchestrator.agent_client.AgentClient`, so connections
+    to the same pod are reused across requests.
+    """
+
+    def __init__(self) -> None:
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            connector = aiohttp.TCPConnector(
+                limit=settings.service_proxy_pool_size,
+                limit_per_host=settings.service_proxy_pool_limit_per_host,
+                ttl_dns_cache=0,  # pod IPs are ephemeral; never cache DNS
+            )
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                # Per-request timeouts are applied at the call site; a service
+                # may legitimately stream for a long time.
+                timeout=aiohttp.ClientTimeout(
+                    total=None, connect=settings.service_proxy_connect_timeout
+                ),
+                auto_decompress=False,  # pass the upstream encoding through untouched
+            )
+        return self._session
+
+    async def request(
+        self,
+        method: str,
+        pod_ip: str,
+        port: int,
+        path: str,
+        query_string: str = "",
+        headers: dict | None = None,
+        body: bytes | None = None,
+        timeout: float | None = None,
+    ) -> aiohttp.ClientResponse:
+        """Send a proxied HTTP request and return the streaming response.
+
+        The response is returned before its body is read so large or streaming
+        payloads are not buffered in the orchestrator. The caller owns the
+        response and must release it.
+        """
+        session = await self._get_session()
+        url = build_upstream_url(pod_ip, port, path, query_string)
+        request_timeout = aiohttp.ClientTimeout(
+            total=(
+                timeout
+                if timeout is not None
+                else settings.service_proxy_timeout_seconds
+            ),
+            connect=settings.service_proxy_connect_timeout,
+        )
+        return await session.request(
+            method,
+            url,
+            headers=headers or {},
+            data=body,
+            timeout=request_timeout,
+            allow_redirects=False,  # redirects are the caller's to interpret
+        )
+
+    async def open_websocket(
+        self,
+        pod_ip: str,
+        port: int,
+        path: str,
+        query_string: str = "",
+        headers: dict | None = None,
+        protocols: tuple[str, ...] = (),
+    ) -> aiohttp.ClientWebSocketResponse:
+        """Open a WebSocket to a service inside the sandbox.
+
+        The caller owns the returned socket and must close it. ``heartbeat`` is
+        left unset: ping/pong is forwarded end to end so the real client's
+        keepalive reaches the real server.
+        """
+        session = await self._get_session()
+        url = build_upstream_url(pod_ip, port, path, query_string, scheme="ws")
+        return await session.ws_connect(
+            url,
+            headers=headers or {},
+            protocols=protocols,
+            max_msg_size=settings.service_proxy_max_message_bytes,
+            autoping=True,
+        )
+
+    async def probe(
+        self, pod_ip: str, port: int, path: str, timeout: float = 5.0
+    ) -> bool:
+        """Return True when the service answers *path* with a 2xx status."""
+        session = await self._get_session()
+        url = build_upstream_url(pod_ip, port, path)
+        try:
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=timeout, connect=timeout)
+            ) as response:
+                return 200 <= response.status < 300
+        except Exception:
+            return False
+
+    async def close(self) -> None:
+        """Close the pooled session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+
+def encode_query(params: dict) -> str:
+    """Encode a mapping as a query string (helper for tests and callers)."""
+    return urlencode(params, doseq=True)

--- a/orchard_env/orchard_env/orchestrator/service_tokens.py
+++ b/orchard_env/orchard_env/orchestrator/service_tokens.py
@@ -1,0 +1,139 @@
+"""Capability tokens for sandbox service endpoints.
+
+A service endpoint URL is handed to programs that cannot attach an
+``X-API-Key`` header — an OpenEnv ``EnvClient`` opens a raw WebSocket, a
+browser follows a link, a curl one-liner is pasted into a notebook. The URL
+therefore has to authenticate itself.
+
+A token is a signed, expiring capability naming exactly one ``(sandbox, port)``
+pair::
+
+    base64url(payload) "." base64url(HMAC-SHA256(secret, payload))
+
+where ``payload`` is ``"<sandbox_id>:<port>:<expires_at>"``. Verification is
+pure computation, so any orchestrator replica can validate a token minted by
+any other without shared state. Possession of a valid token grants access to
+that one port on that one sandbox, until it expires or the port is revoked.
+
+Signing key resolution, in order:
+
+1. ``SERVICE_TOKEN_SECRET`` — set this in multi-replica deployments.
+2. A digest of the configured API keys, which every replica already shares.
+3. A per-process random key, with a warning. Tokens then stop working when a
+   replica restarts or a request lands on a different one.
+"""
+
+import base64
+import hashlib
+import hmac
+import logging
+import secrets
+import time
+
+from orchard_env.orchestrator.settings import settings
+
+logger = logging.getLogger(__name__)
+
+_SEPARATOR = "."
+_PROCESS_SECRET: bytes | None = None
+
+
+class ServiceTokenError(Exception):
+    """Raised when a token is malformed, forged, or expired."""
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _signing_secret() -> bytes:
+    """Return the HMAC key, preferring the explicitly configured one."""
+    configured = settings.service_token_secret
+    if configured:
+        return configured.encode("utf-8")
+
+    api_keys = settings.get_api_keys_set()
+    if api_keys:
+        # Deterministic across replicas: they are configured with the same keys.
+        # Domain-separated so the derived value is not itself a usable API key.
+        joined = "\x00".join(sorted(api_keys))
+        return hashlib.sha256(f"orchard-service-token\x00{joined}".encode()).digest()
+
+    global _PROCESS_SECRET
+    if _PROCESS_SECRET is None:
+        _PROCESS_SECRET = secrets.token_bytes(32)
+        logger.warning(
+            "No SERVICE_TOKEN_SECRET and no API keys configured; service tokens "
+            "are signed with a per-process key. They will not validate across "
+            "orchestrator replicas or restarts. Set SERVICE_TOKEN_SECRET."
+        )
+    return _PROCESS_SECRET
+
+
+def mint_token(
+    sandbox_id: str, port: int, ttl_seconds: int | None = None
+) -> tuple[str, float]:
+    """Mint a capability token for one ``(sandbox_id, port)`` pair.
+
+    Args:
+        sandbox_id: Sandbox the token grants access to.
+        port: Sandbox port the token grants access to.
+        ttl_seconds: Lifetime in seconds. Defaults to
+            ``settings.service_token_ttl_seconds``.
+
+    Returns:
+        A ``(token, expires_at)`` pair, where ``expires_at`` is a Unix timestamp.
+    """
+    if ttl_seconds is None:
+        ttl_seconds = settings.service_token_ttl_seconds
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+
+    expires_at = int(time.time()) + int(ttl_seconds)
+    payload = f"{sandbox_id}:{port}:{expires_at}".encode()
+    signature = hmac.new(_signing_secret(), payload, hashlib.sha256).digest()
+    token = f"{_b64encode(payload)}{_SEPARATOR}{_b64encode(signature)}"
+    return token, float(expires_at)
+
+
+def verify_token(token: str) -> tuple[str, int]:
+    """Verify a capability token and return the ``(sandbox_id, port)`` it names.
+
+    Raises:
+        ServiceTokenError: If the token is malformed, has an invalid signature,
+            or has expired.
+    """
+    if not token or _SEPARATOR not in token:
+        raise ServiceTokenError("Malformed service token")
+
+    encoded_payload, _, encoded_signature = token.partition(_SEPARATOR)
+    try:
+        payload = _b64decode(encoded_payload)
+        signature = _b64decode(encoded_signature)
+    except Exception as exc:
+        raise ServiceTokenError("Malformed service token") from exc
+
+    expected = hmac.new(_signing_secret(), payload, hashlib.sha256).digest()
+    # Constant-time comparison: a fast reject would leak the signature bytewise.
+    if not hmac.compare_digest(signature, expected):
+        raise ServiceTokenError("Invalid service token signature")
+
+    try:
+        sandbox_id, port_text, expires_text = payload.decode("utf-8").rsplit(":", 2)
+        port = int(port_text)
+        expires_at = int(expires_text)
+    except Exception as exc:
+        raise ServiceTokenError("Malformed service token payload") from exc
+
+    if not sandbox_id:
+        raise ServiceTokenError("Malformed service token payload")
+
+    if time.time() > expires_at:
+        raise ServiceTokenError("Service token has expired")
+
+    return sandbox_id, port

--- a/orchard_env/orchard_env/orchestrator/service_tokens.py
+++ b/orchard_env/orchard_env/orchestrator/service_tokens.py
@@ -1,41 +1,31 @@
-"""Capability tokens for sandbox service endpoints.
+"""Signed capabilities for sandbox service endpoints.
 
-A service endpoint URL is handed to programs that cannot attach an
-``X-API-Key`` header — an OpenEnv ``EnvClient`` opens a raw WebSocket, a
-browser follows a link, a curl one-liner is pasted into a notebook. The URL
-therefore has to authenticate itself.
+A service URL is handed to clients that may not support custom authentication
+headers, including an OpenEnv ``EnvClient`` opening a raw WebSocket. The URL
+therefore carries a short-lived capability token.
 
-A token is a signed, expiring capability naming exactly one ``(sandbox, port)``
-pair::
+The HMAC binds four values:
 
-    base64url(payload) "." base64url(HMAC-SHA256(secret, payload))
+* sandbox ID
+* port
+* exposure generation
+* expiration time
 
-where ``payload`` is ``"<sandbox_id>:<port>:<expires_at>"``. Verification is
-pure computation, so any orchestrator replica can validate a token minted by
-any other without shared state. Possession of a valid token grants access to
-that one port on that one sandbox, until it expires or the port is revoked.
-
-Signing key resolution, in order:
-
-1. ``SERVICE_TOKEN_SECRET`` — set this in multi-replica deployments.
-2. A digest of the configured API keys, which every replica already shares.
-3. A per-process random key, with a warning. Tokens then stop working when a
-   replica restarts or a request lands on a different one.
+The generation changes whenever a revoked port is exposed again. This prevents
+an old, unexpired URL from becoming valid after re-exposure.
 """
 
 import base64
 import hashlib
 import hmac
-import logging
-import secrets
+import json
 import time
+from typing import Any
 
 from orchard_env.orchestrator.settings import settings
 
-logger = logging.getLogger(__name__)
-
 _SEPARATOR = "."
-_PROCESS_SECRET: bytes | None = None
+_TOKEN_VERSION = 1
 
 
 class ServiceTokenError(Exception):
@@ -52,61 +42,68 @@ def _b64decode(value: str) -> bytes:
 
 
 def _signing_secret() -> bytes:
-    """Return the HMAC key, preferring the explicitly configured one."""
+    """Return the configured HMAC key, failing closed when it is absent."""
     configured = settings.service_token_secret
-    if configured:
-        return configured.encode("utf-8")
-
-    api_keys = settings.get_api_keys_set()
-    if api_keys:
-        # Deterministic across replicas: they are configured with the same keys.
-        # Domain-separated so the derived value is not itself a usable API key.
-        joined = "\x00".join(sorted(api_keys))
-        return hashlib.sha256(f"orchard-service-token\x00{joined}".encode()).digest()
-
-    global _PROCESS_SECRET
-    if _PROCESS_SECRET is None:
-        _PROCESS_SECRET = secrets.token_bytes(32)
-        logger.warning(
-            "No SERVICE_TOKEN_SECRET and no API keys configured; service tokens "
-            "are signed with a per-process key. They will not validate across "
-            "orchestrator replicas or restarts. Set SERVICE_TOKEN_SECRET."
+    if not configured:
+        raise ServiceTokenError(
+            "SERVICE_TOKEN_SECRET is required when service endpoints are enabled"
         )
-    return _PROCESS_SECRET
+    return configured.encode("utf-8")
+
+
+def _encode_payload(
+    sandbox_id: str, port: int, generation: str, expires_at: int
+) -> bytes:
+    payload: dict[str, Any] = {
+        "v": _TOKEN_VERSION,
+        "s": sandbox_id,
+        "p": port,
+        "g": generation,
+        "e": expires_at,
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
 
 
 def mint_token(
-    sandbox_id: str, port: int, ttl_seconds: int | None = None
+    sandbox_id: str,
+    port: int,
+    generation: str,
+    ttl_seconds: int | None = None,
 ) -> tuple[str, float]:
-    """Mint a capability token for one ``(sandbox_id, port)`` pair.
+    """Mint a capability for one exposure generation.
 
     Args:
         sandbox_id: Sandbox the token grants access to.
         port: Sandbox port the token grants access to.
+        generation: Opaque nonce stored with the active exposure.
         ttl_seconds: Lifetime in seconds. Defaults to
             ``settings.service_token_ttl_seconds``.
 
     Returns:
         A ``(token, expires_at)`` pair, where ``expires_at`` is a Unix timestamp.
     """
+    if not sandbox_id:
+        raise ValueError("sandbox_id must not be empty")
+    if not generation:
+        raise ValueError("generation must not be empty")
     if ttl_seconds is None:
         ttl_seconds = settings.service_token_ttl_seconds
     if ttl_seconds <= 0:
         raise ValueError("ttl_seconds must be positive")
 
     expires_at = int(time.time()) + int(ttl_seconds)
-    payload = f"{sandbox_id}:{port}:{expires_at}".encode()
+    payload = _encode_payload(sandbox_id, port, generation, expires_at)
     signature = hmac.new(_signing_secret(), payload, hashlib.sha256).digest()
     token = f"{_b64encode(payload)}{_SEPARATOR}{_b64encode(signature)}"
     return token, float(expires_at)
 
 
-def verify_token(token: str) -> tuple[str, int]:
-    """Verify a capability token and return the ``(sandbox_id, port)`` it names.
+def verify_token(token: str) -> tuple[str, int, str, int]:
+    """Verify and return ``(sandbox_id, port, generation, expires_at)``.
 
     Raises:
-        ServiceTokenError: If the token is malformed, has an invalid signature,
-            or has expired.
+        ServiceTokenError: If the token is malformed, forged, expired, or uses
+            an unsupported version.
     """
     if not token or _SEPARATOR not in token:
         raise ServiceTokenError("Malformed service token")
@@ -119,21 +116,30 @@ def verify_token(token: str) -> tuple[str, int]:
         raise ServiceTokenError("Malformed service token") from exc
 
     expected = hmac.new(_signing_secret(), payload, hashlib.sha256).digest()
-    # Constant-time comparison: a fast reject would leak the signature bytewise.
     if not hmac.compare_digest(signature, expected):
         raise ServiceTokenError("Invalid service token signature")
 
     try:
-        sandbox_id, port_text, expires_text = payload.decode("utf-8").rsplit(":", 2)
-        port = int(port_text)
-        expires_at = int(expires_text)
-    except Exception as exc:
+        decoded = json.loads(payload)
+        version = decoded["v"]
+        sandbox_id = decoded["s"]
+        port = decoded["p"]
+        generation = decoded["g"]
+        expires_at = decoded["e"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ServiceTokenError("Malformed service token payload") from exc
 
-    if not sandbox_id:
+    if version != _TOKEN_VERSION:
+        raise ServiceTokenError("Unsupported service token version")
+    if not isinstance(sandbox_id, str) or not sandbox_id:
         raise ServiceTokenError("Malformed service token payload")
-
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise ServiceTokenError("Malformed service token payload")
+    if not isinstance(generation, str) or not generation:
+        raise ServiceTokenError("Malformed service token payload")
+    if not isinstance(expires_at, int) or isinstance(expires_at, bool):
+        raise ServiceTokenError("Malformed service token payload")
     if time.time() > expires_at:
         raise ServiceTokenError("Service token has expired")
 
-    return sandbox_id, port
+    return sandbox_id, port, generation, expires_at

--- a/orchard_env/orchard_env/orchestrator/settings.py
+++ b/orchard_env/orchard_env/orchestrator/settings.py
@@ -87,28 +87,27 @@ class Settings(BaseSettings):
     # Lifetime of a capability token. Short by default: the URL is a bearer
     # credential, and callers can mint a new one whenever they need it.
     service_token_ttl_seconds: int = 3600
-    # HMAC key for capability tokens. REQUIRED for multi-replica deployments so
-    # every replica validates tokens minted by any other. When unset the key is
-    # derived from the configured API keys, or randomly generated per process.
+    # HMAC key for capability tokens. Required whenever service endpoints are
+    # enabled; fail closed rather than minting process-local or derived keys.
     service_token_secret: str | None = None
-    # Whether proxied traffic refreshes the sandbox's liveness timer, so an
-    # actively used service is not reaped mid-session by heartbeat cleanup.
+    # Periodically refresh liveness for the full lifetime of an active HTTP
+    # stream or WebSocket, not merely when it is opened.
     service_traffic_refreshes_heartbeat: bool = True
-    # Public base URL clients use to reach the orchestrator, e.g.
-    # "https://orchard.example.com". Set this whenever the orchestrator sits
-    # behind a proxy you do not control end to end: without it the service URL
-    # is derived from request headers, and a forged X-Forwarded-Host would send
-    # the caller (and the capability token in the URL) to an attacker's domain.
+    service_active_heartbeat_interval_seconds: int = 60
+    # Wildcard origin template for untrusted sandbox traffic, e.g.
+    # "https://{subdomain}.sandboxes.example.net". Required when the feature is
+    # enabled. Each capability gets a different hostname, which is the browser
+    # security boundary.
     service_public_base_url: str | None = None
-    # Whether to trust X-Forwarded-Proto/X-Forwarded-Host when
-    # SERVICE_PUBLIC_BASE_URL is unset. Only enable behind a proxy that
-    # overwrites those headers on every request.
-    service_trust_forwarded_headers: bool = False
+    # Development-only escape hatch. Production service origins must use TLS.
+    service_allow_insecure_http: bool = False
     # Proxy connection pool and timeouts.
     service_proxy_pool_size: int = 200
     service_proxy_pool_limit_per_host: int = 20
     service_proxy_connect_timeout: int = 5
+    service_proxy_handshake_timeout_seconds: int = 15
     service_proxy_timeout_seconds: int = 300
+    service_proxy_max_request_bytes: int = 16 * 1024 * 1024
     service_proxy_max_message_bytes: int = 16 * 1024 * 1024
 
     # Sandbox pod probes for the in-pod agent (/health on agent_port).
@@ -154,6 +153,8 @@ class Settings(BaseSettings):
 
     # Redis settings (for multi-replica state sharing)
     redis_url: str = "redis://redis-service.orchestrator.svc.cluster.local:6379/0"
+    redis_password: str | None = None
+    redis_require_auth: bool = True
     use_redis: bool = True  # Set to False to use in-memory store (single replica only)
 
     # Logging

--- a/orchard_env/orchard_env/orchestrator/settings.py
+++ b/orchard_env/orchard_env/orchestrator/settings.py
@@ -74,6 +74,43 @@ class Settings(BaseSettings):
     #                     into a shared emptyDir (~600 MB of ephemeral disk per pod).
     sandbox_tools_volume_mode: str = "image"
 
+    # Sandbox service endpoints — proxy HTTP/WebSocket traffic to a user
+    # service running inside a sandbox (an OpenEnv environment server, an MCP
+    # server, a dev server). Disabled by default: it deliberately opens a hole
+    # in the sandbox boundary, so an operator has to ask for it.
+    enable_service_endpoints: bool = False
+    # Extra ports that may never be exposed, on top of agent_port which is
+    # always refused. Comma- or space-separated.
+    service_reserved_ports: str = ""
+    # Maximum number of ports a single sandbox may expose at once.
+    max_services_per_sandbox: int = 8
+    # Lifetime of a capability token. Short by default: the URL is a bearer
+    # credential, and callers can mint a new one whenever they need it.
+    service_token_ttl_seconds: int = 3600
+    # HMAC key for capability tokens. REQUIRED for multi-replica deployments so
+    # every replica validates tokens minted by any other. When unset the key is
+    # derived from the configured API keys, or randomly generated per process.
+    service_token_secret: str | None = None
+    # Whether proxied traffic refreshes the sandbox's liveness timer, so an
+    # actively used service is not reaped mid-session by heartbeat cleanup.
+    service_traffic_refreshes_heartbeat: bool = True
+    # Public base URL clients use to reach the orchestrator, e.g.
+    # "https://orchard.example.com". Set this whenever the orchestrator sits
+    # behind a proxy you do not control end to end: without it the service URL
+    # is derived from request headers, and a forged X-Forwarded-Host would send
+    # the caller (and the capability token in the URL) to an attacker's domain.
+    service_public_base_url: str | None = None
+    # Whether to trust X-Forwarded-Proto/X-Forwarded-Host when
+    # SERVICE_PUBLIC_BASE_URL is unset. Only enable behind a proxy that
+    # overwrites those headers on every request.
+    service_trust_forwarded_headers: bool = False
+    # Proxy connection pool and timeouts.
+    service_proxy_pool_size: int = 200
+    service_proxy_pool_limit_per_host: int = 20
+    service_proxy_connect_timeout: int = 5
+    service_proxy_timeout_seconds: int = 300
+    service_proxy_max_message_bytes: int = 16 * 1024 * 1024
+
     # Sandbox pod probes for the in-pod agent (/health on agent_port).
     # startupProbe covers the agent boot window AFTER the container starts;
     # while it runs, readiness/liveness are suppressed so an agent that is

--- a/orchard_env/orchard_env/orchestrator/utils.py
+++ b/orchard_env/orchard_env/orchestrator/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import sys
 import time
 import uuid
@@ -12,6 +13,27 @@ from orchard_env.orchestrator.settings import settings
 
 # Context variable for request ID
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+_SERVICE_CAPABILITY_PATH = re.compile(r"/s/[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+
+
+class CapabilityPathRedactionFilter(logging.Filter):
+    """Remove service bearer tokens from every log record and argument."""
+
+    @staticmethod
+    def _redact(value):
+        if isinstance(value, str):
+            return _SERVICE_CAPABILITY_PATH.sub("/s/<redacted>", value)
+        return value
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = self._redact(record.msg)
+        if isinstance(record.args, tuple):
+            record.args = tuple(self._redact(value) for value in record.args)
+        elif isinstance(record.args, dict):
+            record.args = {
+                key: self._redact(value) for key, value in record.args.items()
+            }
+        return True
 
 
 class JSONFormatter(logging.Formatter):
@@ -56,6 +78,7 @@ def setup_logging() -> None:
 
     # Create console handler
     handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(CapabilityPathRedactionFilter())
 
     if settings.log_format == "json":
         handler.setFormatter(JSONFormatter())

--- a/orchard_env/scripts/deploy_k8s.sh
+++ b/orchard_env/scripts/deploy_k8s.sh
@@ -88,6 +88,17 @@ if grep -q REPLACE_WITH_GENERATED_KEY k8s/secret.yaml; then
     echo "  Run 'python k8s/gen_keys.py' and paste real keys before deploying." >&2
     exit 1
 fi
+if grep -q 'ENABLE_SERVICE_ENDPOINTS: "true"' "$TEMP_CONFIGMAP" &&
+   grep -q REPLACE_WITH_A_RANDOM_32_BYTE_SECRET k8s/secret.yaml; then
+    echo "Error: service endpoints are enabled but SERVICE_TOKEN_SECRET is unset." >&2
+    echo "  Replace its placeholder in k8s/secret.yaml with a random value." >&2
+    exit 1
+fi
+if grep -q REPLACE_WITH_A_DIFFERENT_RANDOM_32_BYTE_SECRET k8s/secret.yaml; then
+    echo "Error: k8s/secret.yaml still contains the Redis password placeholder." >&2
+    echo "  Replace REDIS_PASSWORD with a separate random value." >&2
+    exit 1
+fi
 kubectl apply -f k8s/secret.yaml
 
 echo "6. Creating shared sandbox namespace..."

--- a/orchard_env/tests/README.md
+++ b/orchard_env/tests/README.md
@@ -17,11 +17,12 @@ python -m pytest tests/test_exec_timeout.py::TestJobResult -v
 | [`test_exec_timeout.py`](test_exec_timeout.py) | `JobResult` status semantics and the sync-exec polling fallback — in particular that a `"running"` status is **never** treated as complete |
 | [`test_resources.py`](test_resources.py) | `GET /resources` and the CPU/memory quantity parsers |
 | [`test_file_listing.py`](test_file_listing.py) | The file-listing response model — regression cover for the int-vs-str `size` bug that made `GET /files/list` return 500 for non-empty directories |
-| [`test_service_tokens.py`](test_service_tokens.py) | Capability tokens for service endpoints — forged signatures, tampered payloads, expiry, and signing-key derivation |
-| [`test_service_proxy.py`](test_service_proxy.py) | Service-proxy helpers — port allowlisting (the agent port is never exposable), hop-by-hop header stripping, and upstream URL building |
-| [`test_service_endpoints.py`](test_service_endpoints.py) | The service-endpoint routes end to end against a real in-process upstream: exposing, revoking, HTTP proxying (including streaming and compressed bodies), and WebSocket round-trips |
-| [`test_service_allowlist.py`](test_service_allowlist.py) | The exposed-port allowlist, including that concurrent exposes/revokes do not lose each other's writes on either backend |
-| [`test_redis_mutate.py`](test_redis_mutate.py) | `RedisSandboxStore.mutate_sandbox` — the compare-and-set the allowlist depends on, including retry when another replica writes first |
+| [`test_service_tokens.py`](test_service_tokens.py) | Capability tokens — signature, expiry, generation binding, and fail-closed secret handling |
+| [`test_service_proxy.py`](test_service_proxy.py) | Port validation, credential/header filtering, encoded URL construction, and access-log configuration |
+| [`test_service_endpoints.py`](test_service_endpoints.py) | Real HTTP/WebSocket upstreams: origin isolation, revoke/expiry watchdogs, redirects, streaming limits, compressed bodies, raw paths, subprotocols, and handshake deadlines |
+| [`test_service_allowlist.py`](test_service_allowlist.py) | In-memory generation rotation, limits, concurrency, and cache cleanup |
+| [`test_redis_mutate.py`](test_redis_mutate.py) | Redis CAS, separate generation state, sandbox-incarnation binding, and pod-IP binding |
+| [`test_service_security.py`](test_service_security.py) | Agent-port override, authenticated/network-isolated Redis, SDK key scoping, and capability log redaction |
 
 ## Integration scripts — `tests/integration/`
 

--- a/orchard_env/tests/README.md
+++ b/orchard_env/tests/README.md
@@ -17,6 +17,11 @@ python -m pytest tests/test_exec_timeout.py::TestJobResult -v
 | [`test_exec_timeout.py`](test_exec_timeout.py) | `JobResult` status semantics and the sync-exec polling fallback — in particular that a `"running"` status is **never** treated as complete |
 | [`test_resources.py`](test_resources.py) | `GET /resources` and the CPU/memory quantity parsers |
 | [`test_file_listing.py`](test_file_listing.py) | The file-listing response model — regression cover for the int-vs-str `size` bug that made `GET /files/list` return 500 for non-empty directories |
+| [`test_service_tokens.py`](test_service_tokens.py) | Capability tokens for service endpoints — forged signatures, tampered payloads, expiry, and signing-key derivation |
+| [`test_service_proxy.py`](test_service_proxy.py) | Service-proxy helpers — port allowlisting (the agent port is never exposable), hop-by-hop header stripping, and upstream URL building |
+| [`test_service_endpoints.py`](test_service_endpoints.py) | The service-endpoint routes end to end against a real in-process upstream: exposing, revoking, HTTP proxying (including streaming and compressed bodies), and WebSocket round-trips |
+| [`test_service_allowlist.py`](test_service_allowlist.py) | The exposed-port allowlist, including that concurrent exposes/revokes do not lose each other's writes on either backend |
+| [`test_redis_mutate.py`](test_redis_mutate.py) | `RedisSandboxStore.mutate_sandbox` — the compare-and-set the allowlist depends on, including retry when another replica writes first |
 
 ## Integration scripts — `tests/integration/`
 
@@ -36,6 +41,7 @@ export SANDBOX_API_KEY="your-api-key"
 | [`sandbox_tools.py`](integration/sandbox_tools.py) | 11 checks on the bundled agent harnesses: PATH ordering, read-only mount, login shell, `kubectl exec` reachability, and that `hermes` leaves the image's own `python` untouched |
 | [`bench_concurrent.py`](integration/bench_concurrent.py) | Concurrency benchmark — P50/P90/P95/P99 latency for create/exec/delete |
 | [`bench_concurrent_pty.py`](integration/bench_concurrent_pty.py) | The same, for PTY sessions |
+| [`service_endpoint.py`](integration/service_endpoint.py) | Service endpoints against a live cluster: launch a server inside a sandbox, expose it, drive it over HTTP, confirm a large response is not truncated, and confirm revocation is immediate. Needs `ENABLE_SERVICE_ENDPOINTS=true`. |
 
 ```bash
 python tests/integration/soak.py --mode both --rounds 50

--- a/orchard_env/tests/integration/service_endpoint.py
+++ b/orchard_env/tests/integration/service_endpoint.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Integration check for sandbox service endpoints (needs a live orchestrator).
+
+Starts a small HTTP + WebSocket server inside a real sandbox, exposes it, and
+drives it from outside the cluster:
+
+1. create a sandbox
+2. write and launch a server on a port inside it
+3. expose that port and wait for it to answer
+4. GET through the proxy
+5. round-trip text and binary frames over the proxied WebSocket
+6. confirm a large response survives streaming intact
+7. confirm revocation takes effect immediately
+8. confirm the in-pod agent port can never be exposed
+
+Usage::
+
+    export SANDBOX_BASE_URL="http://your-orchestrator-host"
+    export SANDBOX_API_KEY="your-api-key"
+    python tests/integration/service_endpoint.py
+
+Requires ``ENABLE_SERVICE_ENDPOINTS=true`` on the orchestrator. Deliberately
+not named ``test_*.py``: importing it fires real network calls.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from orchard_env import SandboxClient  # noqa: E402
+
+# Written into the sandbox and launched there. Kept dependency-free so it runs
+# in any image with a Python interpreter.
+SERVER_SOURCE = """
+import http.server, json, socketserver, sys
+
+PORT = int(sys.argv[1])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            body = json.dumps({"status": "healthy"}).encode()
+        elif self.path == "/big":
+            body = ("x" * 1024 * 512).encode()
+        else:
+            self.send_response(404); self.end_headers(); return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("0.0.0.0", PORT), Handler) as httpd:
+    httpd.serve_forever()
+"""
+
+SERVICE_PORT = 8000
+
+
+def check(label: str, condition: bool) -> None:
+    status = "PASS" if condition else "FAIL"
+    print(f"[{status}] {label}")
+    if not condition:
+        raise SystemExit(1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default="python:3.11-slim")
+    parser.add_argument("--keep", action="store_true", help="do not delete the sandbox")
+    args = parser.parse_args()
+
+    if not os.environ.get("SANDBOX_BASE_URL"):
+        print("SANDBOX_BASE_URL is not set", file=sys.stderr)
+        return 2
+
+    with SandboxClient() as client:
+        print(f"Creating sandbox from {args.image} ...")
+        sandbox = client.create_sandbox(args.image)
+        try:
+            print(f"Sandbox {sandbox.sandbox_id} ready")
+
+            # 1. Put a server inside the sandbox and start it in the background.
+            sandbox.upload_content(SERVER_SOURCE.encode(), "/tmp/service.py")
+            sandbox.exec(
+                f"nohup python /tmp/service.py {SERVICE_PORT} "
+                "> /tmp/service.log 2>&1 & echo started",
+                timeout=30,
+            )
+
+            # 2. Expose it. wait_ready matters: sandbox readiness only covers
+            #    the in-pod agent, so the server may still be binding.
+            endpoint = sandbox.expose_service(
+                SERVICE_PORT, wait_ready=True, health_path="/health", ready_timeout=60
+            )
+            check("expose_service returned a URL", bool(endpoint.url))
+            check("port matches", endpoint.port == SERVICE_PORT)
+            check("expiry is in the future", endpoint.expires_at > time.time())
+
+            # 3. The URL authenticates itself: no X-API-Key header here.
+            response = requests.get(f"{endpoint.url}/health", timeout=30)
+            check("GET /health through the proxy", response.status_code == 200)
+            check("body is intact", response.json() == {"status": "healthy"})
+
+            # 4. A large body must survive streaming without truncation.
+            big = requests.get(f"{endpoint.url}/big", timeout=60)
+            check("large response status", big.status_code == 200)
+            check("large response length", len(big.content) == 1024 * 512)
+
+            # 5. The listing reflects what is exposed.
+            check("service is listed", SERVICE_PORT in sandbox.list_services())
+
+            # 6. Revocation is immediate, even though the URL has not expired.
+            sandbox.revoke_service(SERVICE_PORT)
+            revoked = requests.get(f"{endpoint.url}/health", timeout=30)
+            check("revoked URL is refused", revoked.status_code == 403)
+            check(
+                "service no longer listed", SERVICE_PORT not in sandbox.list_services()
+            )
+
+            # 7. The agent port must never be exposable.
+            try:
+                sandbox.expose_service(9090)
+                check("agent port refused", False)
+            except Exception:
+                check("agent port refused", True)
+
+            print("\nAll service endpoint checks passed.")
+            return 0
+        finally:
+            if args.keep:
+                print(f"Keeping sandbox {sandbox.sandbox_id}")
+            else:
+                sandbox.delete()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchard_env/tests/integration/service_endpoint.py
+++ b/orchard_env/tests/integration/service_endpoint.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Integration check for sandbox service endpoints (needs a live orchestrator).
 
-Starts a small HTTP + WebSocket server inside a real sandbox, exposes it, and
-drives it from outside the cluster:
+Starts a small HTTP server inside a real sandbox, exposes it, and drives it
+from outside the cluster:
 
 1. create a sandbox
 2. write and launch a server on a port inside it
 3. expose that port and wait for it to answer
 4. GET through the proxy
-5. round-trip text and binary frames over the proxied WebSocket
-6. confirm a large response survives streaming intact
-7. confirm revocation takes effect immediately
-8. confirm the in-pod agent port can never be exposed
+5. confirm a large response survives streaming intact
+6. confirm revocation takes effect immediately
+7. confirm the in-pod agent port can never be exposed
 
 Usage::
 
@@ -19,8 +18,10 @@ Usage::
     export SANDBOX_API_KEY="your-api-key"
     python tests/integration/service_endpoint.py
 
-Requires ``ENABLE_SERVICE_ENDPOINTS=true`` on the orchestrator. Deliberately
-not named ``test_*.py``: importing it fires real network calls.
+Requires ``ENABLE_SERVICE_ENDPOINTS=true``, ``SERVICE_PUBLIC_BASE_URL``, and
+``SERVICE_TOKEN_SECRET`` on the orchestrator. WebSocket behavior is covered by
+the route-level test suite against a real upstream server. Deliberately not
+named ``test_*.py``: importing it fires real network calls.
 """
 
 import argparse

--- a/orchard_env/tests/test_redis_mutate.py
+++ b/orchard_env/tests/test_redis_mutate.py
@@ -1,0 +1,155 @@
+"""Unit tests for RedisSandboxStore.mutate_sandbox.
+
+The exposed-port allowlist relies on this being a genuine compare-and-set, so
+these tests drive it through a fake that follows redis-py's real pipeline
+semantics: `watch`/`get` execute immediately and are awaited, commands after
+`multi()` are buffered and are not, and a concurrent write raises `WatchError`
+from `execute()`.
+"""
+
+import json
+
+import pytest
+from redis.exceptions import WatchError
+
+from orchard_env.orchestrator.redis_store import RedisSandboxStore
+
+
+class FakePipeline:
+    """Mimics redis.asyncio Pipeline for the watch/multi/execute flow."""
+
+    def __init__(self, store: "FakeRedisClient"):
+        self._store = store
+        self._watched_key: str | None = None
+        self._watched_version: int | None = None
+        self._buffered: list[tuple] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def watch(self, key):
+        self._watched_key = key
+        self._watched_version = self._store.versions.get(key, 0)
+
+    async def unwatch(self):
+        self._watched_key = None
+
+    async def get(self, key):
+        # The store may mutate between watch and get in the real world; the
+        # version check at execute() is what catches it.
+        return self._store.data.get(key)
+
+    def multi(self):
+        self._buffered = []
+
+    def set(self, key, value, ex=None):
+        # Buffered: deliberately not a coroutine, matching redis-py.
+        self._buffered.append((key, value))
+        return self
+
+    async def execute(self):
+        key = self._watched_key
+        if (
+            key is not None
+            and self._store.versions.get(key, 0) != self._watched_version
+        ):
+            raise WatchError("WATCHed key changed")
+        for buffered_key, value in self._buffered:
+            self._store.write(buffered_key, value)
+        return [True] * len(self._buffered)
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.data: dict[str, str] = {}
+        self.versions: dict[str, int] = {}
+        self.on_watch = None
+
+    def write(self, key, value):
+        self.data[key] = value
+        self.versions[key] = self.versions.get(key, 0) + 1
+
+    def pipeline(self):
+        return FakePipeline(self)
+
+
+@pytest.fixture
+def store():
+    redis_store = RedisSandboxStore(redis_url="redis://unused")
+    client = FakeRedisClient()
+    client.write("sandbox:s1", json.dumps({"sandbox_id": "s1", "exposed_ports": []}))
+
+    async def _ensure_connected():
+        return client
+
+    redis_store._ensure_connected = _ensure_connected
+    redis_store._fake_client = client
+    return redis_store
+
+
+class TestMutateSandbox:
+    @pytest.mark.asyncio
+    async def test_applies_the_mutation(self, store):
+        result = await store.mutate_sandbox(
+            "s1", lambda record: {"exposed_ports": [8000]}
+        )
+        assert result["exposed_ports"] == [8000]
+        stored = json.loads(store._fake_client.data["sandbox:s1"])
+        assert stored["exposed_ports"] == [8000]
+
+    @pytest.mark.asyncio
+    async def test_mutation_sees_current_state(self, store):
+        await store.mutate_sandbox("s1", lambda r: {"exposed_ports": [8000]})
+        seen = {}
+
+        def mutate(record):
+            seen["ports"] = record["exposed_ports"]
+            return {"exposed_ports": record["exposed_ports"] + [8001]}
+
+        await store.mutate_sandbox("s1", mutate)
+        assert seen["ports"] == [8000]
+
+    @pytest.mark.asyncio
+    async def test_returning_none_writes_nothing(self, store):
+        assert await store.mutate_sandbox("s1", lambda record: None) is None
+        stored = json.loads(store._fake_client.data["sandbox:s1"])
+        assert stored["exposed_ports"] == []
+
+    @pytest.mark.asyncio
+    async def test_missing_sandbox_returns_none(self, store):
+        assert await store.mutate_sandbox("gone", lambda record: {"a": 1}) is None
+
+    @pytest.mark.asyncio
+    async def test_conflicting_write_is_retried(self, store):
+        """A concurrent writer must cause a retry, not a lost update."""
+        client = store._fake_client
+        attempts = {"count": 0}
+
+        def mutate(record):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                # Simulate another replica writing between our watch and exec.
+                client.write(
+                    "sandbox:s1",
+                    json.dumps({"sandbox_id": "s1", "exposed_ports": [9001]}),
+                )
+            return {"exposed_ports": record["exposed_ports"] + [8000]}
+
+        result = await store.mutate_sandbox("s1", mutate)
+        assert attempts["count"] == 2
+        # The retry observed the other replica's write and preserved it.
+        assert result["exposed_ports"] == [9001, 8000]
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts(self, store):
+        client = store._fake_client
+
+        def mutate(record):
+            client.write("sandbox:s1", json.dumps({"sandbox_id": "s1"}))
+            return {"exposed_ports": [8000]}
+
+        with pytest.raises(TimeoutError, match="contention"):
+            await store.mutate_sandbox("s1", mutate, max_attempts=3)

--- a/orchard_env/tests/test_redis_mutate.py
+++ b/orchard_env/tests/test_redis_mutate.py
@@ -1,11 +1,4 @@
-"""Unit tests for RedisSandboxStore.mutate_sandbox.
-
-The exposed-port allowlist relies on this being a genuine compare-and-set, so
-these tests drive it through a fake that follows redis-py's real pipeline
-semantics: `watch`/`get` execute immediately and are awaited, commands after
-`multi()` are buffered and are not, and a concurrent write raises `WatchError`
-from `execute()`.
-"""
+"""Tests for Redis sandbox compare-and-set and separate service state."""
 
 import json
 
@@ -16,13 +9,12 @@ from orchard_env.orchestrator.redis_store import RedisSandboxStore
 
 
 class FakePipeline:
-    """Mimics redis.asyncio Pipeline for the watch/multi/execute flow."""
+    """Small redis.asyncio Pipeline model for WATCH/MULTI tests."""
 
-    def __init__(self, store: "FakeRedisClient"):
-        self._store = store
-        self._watched_key: str | None = None
-        self._watched_version: int | None = None
-        self._buffered: list[tuple] = []
+    def __init__(self, client: "FakeRedisClient"):
+        self.client = client
+        self.watched: dict[str, int] = {}
+        self.buffered: list[tuple] = []
 
     async def __aenter__(self):
         return self
@@ -30,57 +22,120 @@ class FakePipeline:
     async def __aexit__(self, *exc_info):
         return False
 
-    async def watch(self, key):
-        self._watched_key = key
-        self._watched_version = self._store.versions.get(key, 0)
+    async def watch(self, *keys):
+        self.watched = {key: self.client.versions.get(key, 0) for key in keys}
 
     async def unwatch(self):
-        self._watched_key = None
+        self.watched = {}
 
     async def get(self, key):
-        # The store may mutate between watch and get in the real world; the
-        # version check at execute() is what catches it.
-        return self._store.data.get(key)
+        return self.client.data.get(key)
+
+    async def exists(self, key):
+        return int(key in self.client.data or key in self.client.hashes)
+
+    async def hget(self, key, field):
+        return self.client.hashes.get(key, {}).get(field)
+
+    async def hlen(self, key):
+        return len(self.client.hashes.get(key, {}))
 
     def multi(self):
-        self._buffered = []
+        self.buffered = []
 
     def set(self, key, value, ex=None):
-        # Buffered: deliberately not a coroutine, matching redis-py.
-        self._buffered.append((key, value))
+        self.buffered.append(("set", key, value))
+        return self
+
+    def hset(self, key, field, value):
+        self.buffered.append(("hset", key, field, value))
+        return self
+
+    def expire(self, key, ttl):
+        self.buffered.append(("expire", key, ttl))
         return self
 
     async def execute(self):
-        key = self._watched_key
-        if (
-            key is not None
-            and self._store.versions.get(key, 0) != self._watched_version
+        if any(
+            self.client.versions.get(key, 0) != version
+            for key, version in self.watched.items()
         ):
             raise WatchError("WATCHed key changed")
-        for buffered_key, value in self._buffered:
-            self._store.write(buffered_key, value)
-        return [True] * len(self._buffered)
+        for operation in self.buffered:
+            if operation[0] == "set":
+                _, key, value = operation
+                self.client.write(key, value)
+            elif operation[0] == "hset":
+                _, key, field, value = operation
+                self.client.hashes.setdefault(key, {})[field] = value
+                self.client.bump(key)
+        return [True] * len(self.buffered)
 
 
 class FakeRedisClient:
     def __init__(self):
         self.data: dict[str, str] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
         self.versions: dict[str, int] = {}
-        self.on_watch = None
+
+    def bump(self, key):
+        self.versions[key] = self.versions.get(key, 0) + 1
 
     def write(self, key, value):
         self.data[key] = value
-        self.versions[key] = self.versions.get(key, 0) + 1
+        self.bump(key)
 
     def pipeline(self):
         return FakePipeline(self)
+
+    async def expire(self, key, ttl):
+        return key in self.data or key in self.hashes
+
+    async def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
+    async def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+    async def hdel(self, key, field):
+        if field not in self.hashes.get(key, {}):
+            return 0
+        del self.hashes[key][field]
+        self.bump(key)
+        return 1
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.write(key, value)
+        return True
+
+    async def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            deleted += int(key in self.data or key in self.hashes)
+            self.data.pop(key, None)
+            self.hashes.pop(key, None)
+            self.bump(key)
+        return deleted
 
 
 @pytest.fixture
 def store():
     redis_store = RedisSandboxStore(redis_url="redis://unused")
     client = FakeRedisClient()
-    client.write("sandbox:s1", json.dumps({"sandbox_id": "s1", "exposed_ports": []}))
+    client.write(
+        "sandbox:s1",
+        json.dumps(
+            {
+                "sandbox_id": "s1",
+                "created_at": 100.0,
+                "ready": False,
+                "last_heartbeat": None,
+            }
+        ),
+    )
 
     async def _ensure_connected():
         return client
@@ -90,66 +145,121 @@ def store():
     return redis_store
 
 
-class TestMutateSandbox:
+class TestSandboxMutation:
     @pytest.mark.asyncio
-    async def test_applies_the_mutation(self, store):
-        result = await store.mutate_sandbox(
-            "s1", lambda record: {"exposed_ports": [8000]}
-        )
-        assert result["exposed_ports"] == [8000]
+    async def test_update_uses_compare_and_set(self, store):
+        assert await store.update_sandbox("s1", {"last_heartbeat": 123.0})
         stored = json.loads(store._fake_client.data["sandbox:s1"])
-        assert stored["exposed_ports"] == [8000]
+        assert stored["last_heartbeat"] == 123.0
 
     @pytest.mark.asyncio
-    async def test_mutation_sees_current_state(self, store):
-        await store.mutate_sandbox("s1", lambda r: {"exposed_ports": [8000]})
-        seen = {}
-
-        def mutate(record):
-            seen["ports"] = record["exposed_ports"]
-            return {"exposed_ports": record["exposed_ports"] + [8001]}
-
-        await store.mutate_sandbox("s1", mutate)
-        assert seen["ports"] == [8000]
-
-    @pytest.mark.asyncio
-    async def test_returning_none_writes_nothing(self, store):
-        assert await store.mutate_sandbox("s1", lambda record: None) is None
-        stored = json.loads(store._fake_client.data["sandbox:s1"])
-        assert stored["exposed_ports"] == []
-
-    @pytest.mark.asyncio
-    async def test_missing_sandbox_returns_none(self, store):
-        assert await store.mutate_sandbox("gone", lambda record: {"a": 1}) is None
-
-    @pytest.mark.asyncio
-    async def test_conflicting_write_is_retried(self, store):
-        """A concurrent writer must cause a retry, not a lost update."""
+    async def test_conflicting_field_write_is_preserved(self, store):
         client = store._fake_client
         attempts = {"count": 0}
 
         def mutate(record):
             attempts["count"] += 1
             if attempts["count"] == 1:
-                # Simulate another replica writing between our watch and exec.
                 client.write(
                     "sandbox:s1",
-                    json.dumps({"sandbox_id": "s1", "exposed_ports": [9001]}),
+                    json.dumps(
+                        {
+                            "sandbox_id": "s1",
+                            "created_at": 100.0,
+                            "ready": True,
+                            "last_heartbeat": None,
+                        }
+                    ),
                 )
-            return {"exposed_ports": record["exposed_ports"] + [8000]}
+            return {"last_heartbeat": 123.0}
 
         result = await store.mutate_sandbox("s1", mutate)
         assert attempts["count"] == 2
-        # The retry observed the other replica's write and preserved it.
-        assert result["exposed_ports"] == [9001, 8000]
+        assert result["ready"] is True
+        assert result["last_heartbeat"] == 123.0
 
     @pytest.mark.asyncio
-    async def test_gives_up_after_max_attempts(self, store):
+    async def test_missing_sandbox_returns_none(self, store):
+        assert await store.mutate_sandbox("gone", lambda record: {"a": 1}) is None
+
+    @pytest.mark.asyncio
+    async def test_contention_eventually_fails(self, store):
         client = store._fake_client
 
         def mutate(record):
-            client.write("sandbox:s1", json.dumps({"sandbox_id": "s1"}))
-            return {"exposed_ports": [8000]}
+            client.write("sandbox:s1", json.dumps(record))
+            return {"ready": True}
 
         with pytest.raises(TimeoutError, match="contention"):
             await store.mutate_sandbox("s1", mutate, max_attempts=3)
+
+
+class TestServiceState:
+    @pytest.mark.asyncio
+    async def test_expose_creates_separate_hash_state(self, store):
+        result = await store.expose_service("s1", 8000, "g1", max_services=8)
+        assert result == ("g1", True)
+        assert await store.get_service_generation("s1", 8000, 100.0) == "g1"
+        sandbox = json.loads(store._fake_client.data["sandbox:s1"])
+        assert "exposed_ports" not in sandbox
+
+    @pytest.mark.asyncio
+    async def test_stale_state_cannot_authorize_reused_sandbox_id(self, store):
+        await store.expose_service("s1", 8000, "old", max_services=8)
+        store._fake_client.write(
+            "sandbox:s1",
+            json.dumps(
+                {
+                    "sandbox_id": "s1",
+                    "created_at": 200.0,
+                    "ready": True,
+                    "last_heartbeat": None,
+                }
+            ),
+        )
+        assert await store.get_service_generation("s1", 8000, 200.0) is None
+        assert await store.expose_service("s1", 8000, "new", max_services=8) == (
+            "new",
+            True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_active_reexpose_returns_same_generation(self, store):
+        await store.expose_service("s1", 8000, "g1", max_services=8)
+        assert await store.expose_service("s1", 8000, "g2", max_services=8) == (
+            "g1",
+            False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_revoke_then_reexpose_uses_new_generation(self, store):
+        await store.expose_service("s1", 8000, "g1", max_services=8)
+        assert await store.revoke_service("s1", 8000)
+        assert await store.expose_service("s1", 8000, "g2", max_services=8) == (
+            "g2",
+            True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_limit_is_atomic(self, store):
+        await store.expose_service("s1", 8000, "g1", max_services=1)
+        with pytest.raises(ValueError, match="MAX_SERVICES_PER_SANDBOX"):
+            await store.expose_service("s1", 8001, "g2", max_services=1)
+
+    @pytest.mark.asyncio
+    async def test_unknown_sandbox_not_exposed(self, store):
+        assert await store.expose_service("gone", 8000, "g1", max_services=8) is None
+
+
+class TestPodIpState:
+    @pytest.mark.asyncio
+    async def test_pod_ip_is_bound_to_sandbox_instance(self, store):
+        await store.store_pod_ip("s1", "10.0.0.1", 100.0)
+        assert await store.get_pod_ip("s1", 100.0) == "10.0.0.1"
+        assert await store.get_pod_ip("s1", 200.0) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_cached_ip(self, store):
+        await store.store_pod_ip("s1", "10.0.0.1", 100.0)
+        await store.delete_pod_ip("s1")
+        assert await store.get_pod_ip("s1", 100.0) is None

--- a/orchard_env/tests/test_service_allowlist.py
+++ b/orchard_env/tests/test_service_allowlist.py
@@ -1,0 +1,200 @@
+"""Unit tests for the exposed-port allowlist on SandboxManager.
+
+The allowlist is what makes a service URL usable and what makes revocation
+immediate, so these tests pin its concurrency behaviour: a naive
+read-modify-write loses ports when two callers expose different ports at the
+same time.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from orchard_env.orchestrator.sandbox_manager import Sandbox, SandboxManager
+
+
+def _make_sandbox(**overrides) -> Sandbox:
+    defaults = dict(
+        sandbox_id="s1",
+        namespace="sandbox-pods",
+        image="python:3.11-slim",
+        pod_name="sandbox-s1",
+        block_network=True,
+        cpu="1",
+        memory="1Gi",
+        ready=True,
+    )
+    defaults.update(overrides)
+    return Sandbox(**defaults)
+
+
+class FakeRedisStore:
+    """Redis stand-in whose transaction semantics match the real store.
+
+    ``mutate_sandbox`` is serialised (as a Redis WATCH/MULTI transaction is),
+    while ``update_sandbox`` deliberately interleaves a read and a write so the
+    lost-update bug is reproducible in a test.
+    """
+
+    def __init__(self, record: dict):
+        self.data = json.dumps(record)
+        self._lock = asyncio.Lock()
+
+    async def get_sandbox(self, sandbox_id):
+        return json.loads(self.data)
+
+    async def sandbox_exists(self, sandbox_id):
+        return True
+
+    async def update_sandbox(self, sandbox_id, updates):
+        record = json.loads(self.data)
+        await asyncio.sleep(0)  # yield: this is where the lost update happens
+        record.update(updates)
+        self.data = json.dumps(record)
+        return True
+
+    async def mutate_sandbox(self, sandbox_id, mutate, max_attempts=5):
+        async with self._lock:
+            record = json.loads(self.data)
+            updates = mutate(record)
+            if updates is None:
+                return None
+            record.update(updates)
+            await asyncio.sleep(0)
+            self.data = json.dumps(record)
+            return record
+
+
+@pytest.fixture
+def memory_manager():
+    """A manager backed by the in-memory store (single-replica mode)."""
+    with patch("orchard_env.orchestrator.sandbox_manager.settings.use_redis", False):
+        manager = SandboxManager(k8s_client=None)
+        manager._sandboxes["s1"] = _make_sandbox()
+        yield manager
+
+
+@pytest.fixture
+def redis_manager():
+    """A manager backed by the fake Redis store."""
+    manager = SandboxManager(k8s_client=None)
+    store = FakeRedisStore(_make_sandbox().to_dict())
+    manager._redis_store = store
+
+    async def _get_store():
+        return store
+
+    manager._get_redis_store = _get_store
+    return manager
+
+
+class TestExposeAndRevoke:
+    @pytest.mark.asyncio
+    async def test_expose_adds_the_port(self, memory_manager):
+        assert await memory_manager.expose_service("s1", 8000) == [8000]
+        assert memory_manager._sandboxes["s1"].exposed_ports == [8000]
+
+    @pytest.mark.asyncio
+    async def test_expose_is_idempotent(self, memory_manager):
+        for _ in range(3):
+            assert await memory_manager.expose_service("s1", 8000) == [8000]
+
+    @pytest.mark.asyncio
+    async def test_expose_unknown_sandbox_returns_none(self, memory_manager):
+        assert await memory_manager.expose_service("nope", 8000) is None
+
+    @pytest.mark.asyncio
+    async def test_expose_enforces_the_limit(self, memory_manager):
+        with patch(
+            "orchard_env.orchestrator.sandbox_manager.settings."
+            "max_services_per_sandbox",
+            2,
+        ):
+            await memory_manager.expose_service("s1", 8000)
+            await memory_manager.expose_service("s1", 8001)
+            with pytest.raises(ValueError, match="MAX_SERVICES_PER_SANDBOX"):
+                await memory_manager.expose_service("s1", 8002)
+
+    @pytest.mark.asyncio
+    async def test_revoke_removes_the_port(self, memory_manager):
+        await memory_manager.expose_service("s1", 8000)
+        assert await memory_manager.revoke_service("s1", 8000) is True
+        assert memory_manager._sandboxes["s1"].exposed_ports == []
+
+    @pytest.mark.asyncio
+    async def test_revoking_an_unexposed_port_is_false(self, memory_manager):
+        assert await memory_manager.revoke_service("s1", 8000) is False
+
+    @pytest.mark.asyncio
+    async def test_revoke_unknown_sandbox_is_false(self, memory_manager):
+        assert await memory_manager.revoke_service("nope", 8000) is False
+
+
+class TestConcurrency:
+    """Two callers exposing different ports must not lose each other's write."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_exposes_all_land_in_memory_mode(self, memory_manager):
+        ports = list(range(8000, 8010))
+        with patch(
+            "orchard_env.orchestrator.sandbox_manager.settings."
+            "max_services_per_sandbox",
+            len(ports),
+        ):
+            await asyncio.gather(
+                *(memory_manager.expose_service("s1", port) for port in ports)
+            )
+        assert sorted(memory_manager._sandboxes["s1"].exposed_ports) == ports
+
+    @pytest.mark.asyncio
+    async def test_concurrent_exposes_all_land_with_redis(self, redis_manager):
+        ports = list(range(8000, 8010))
+        with patch(
+            "orchard_env.orchestrator.sandbox_manager.settings."
+            "max_services_per_sandbox",
+            len(ports),
+        ):
+            await asyncio.gather(
+                *(redis_manager.expose_service("s1", port) for port in ports)
+            )
+        record = json.loads(redis_manager._redis_store.data)
+        assert sorted(record["exposed_ports"]) == ports
+
+    @pytest.mark.asyncio
+    async def test_concurrent_revokes_all_land_with_redis(self, redis_manager):
+        ports = list(range(8000, 8006))
+        with patch(
+            "orchard_env.orchestrator.sandbox_manager.settings."
+            "max_services_per_sandbox",
+            len(ports),
+        ):
+            for port in ports:
+                await redis_manager.expose_service("s1", port)
+
+            await asyncio.gather(
+                *(redis_manager.revoke_service("s1", port) for port in ports[:3])
+            )
+
+        record = json.loads(redis_manager._redis_store.data)
+        assert sorted(record["exposed_ports"]) == ports[3:]
+
+    @pytest.mark.asyncio
+    async def test_naive_update_would_lose_writes(self, redis_manager):
+        """Demonstrates the bug the atomic path avoids.
+
+        Using the plain last-write-wins update for the same workload drops
+        ports, which is exactly why expose/revoke do not use it.
+        """
+        store = redis_manager._redis_store
+
+        async def naive_expose(port):
+            record = await store.get_sandbox("s1")
+            exposed = list(record.get("exposed_ports") or [])
+            exposed.append(port)
+            await store.update_sandbox("s1", {"exposed_ports": exposed})
+
+        await asyncio.gather(*(naive_expose(p) for p in range(8000, 8010)))
+        record = json.loads(store.data)
+        assert len(record["exposed_ports"]) < 10

--- a/orchard_env/tests/test_service_allowlist.py
+++ b/orchard_env/tests/test_service_allowlist.py
@@ -1,22 +1,15 @@
-"""Unit tests for the exposed-port allowlist on SandboxManager.
-
-The allowlist is what makes a service URL usable and what makes revocation
-immediate, so these tests pin its concurrency behaviour: a naive
-read-modify-write loses ports when two callers expose different ports at the
-same time.
-"""
+"""Tests for per-sandbox service generations in SandboxManager."""
 
 import asyncio
-import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from orchard_env.orchestrator.sandbox_manager import Sandbox, SandboxManager
 
 
-def _make_sandbox(**overrides) -> Sandbox:
-    defaults = dict(
+def _make_sandbox() -> Sandbox:
+    return Sandbox(
         sandbox_id="s1",
         namespace="sandbox-pods",
         image="python:3.11-slim",
@@ -26,87 +19,51 @@ def _make_sandbox(**overrides) -> Sandbox:
         memory="1Gi",
         ready=True,
     )
-    defaults.update(overrides)
-    return Sandbox(**defaults)
-
-
-class FakeRedisStore:
-    """Redis stand-in whose transaction semantics match the real store.
-
-    ``mutate_sandbox`` is serialised (as a Redis WATCH/MULTI transaction is),
-    while ``update_sandbox`` deliberately interleaves a read and a write so the
-    lost-update bug is reproducible in a test.
-    """
-
-    def __init__(self, record: dict):
-        self.data = json.dumps(record)
-        self._lock = asyncio.Lock()
-
-    async def get_sandbox(self, sandbox_id):
-        return json.loads(self.data)
-
-    async def sandbox_exists(self, sandbox_id):
-        return True
-
-    async def update_sandbox(self, sandbox_id, updates):
-        record = json.loads(self.data)
-        await asyncio.sleep(0)  # yield: this is where the lost update happens
-        record.update(updates)
-        self.data = json.dumps(record)
-        return True
-
-    async def mutate_sandbox(self, sandbox_id, mutate, max_attempts=5):
-        async with self._lock:
-            record = json.loads(self.data)
-            updates = mutate(record)
-            if updates is None:
-                return None
-            record.update(updates)
-            await asyncio.sleep(0)
-            self.data = json.dumps(record)
-            return record
 
 
 @pytest.fixture
 def memory_manager():
-    """A manager backed by the in-memory store (single-replica mode)."""
     with patch("orchard_env.orchestrator.sandbox_manager.settings.use_redis", False):
         manager = SandboxManager(k8s_client=None)
         manager._sandboxes["s1"] = _make_sandbox()
         yield manager
 
 
-@pytest.fixture
-def redis_manager():
-    """A manager backed by the fake Redis store."""
-    manager = SandboxManager(k8s_client=None)
-    store = FakeRedisStore(_make_sandbox().to_dict())
-    manager._redis_store = store
-
-    async def _get_store():
-        return store
-
-    manager._get_redis_store = _get_store
-    return manager
-
-
 class TestExposeAndRevoke:
     @pytest.mark.asyncio
-    async def test_expose_adds_the_port(self, memory_manager):
-        assert await memory_manager.expose_service("s1", 8000) == [8000]
-        assert memory_manager._sandboxes["s1"].exposed_ports == [8000]
+    async def test_expose_creates_a_generation(self, memory_manager):
+        generation, created = await memory_manager.expose_service("s1", 8000)
+        assert generation
+        assert created is True
+        assert await memory_manager.get_service_generation("s1", 8000) == generation
 
     @pytest.mark.asyncio
-    async def test_expose_is_idempotent(self, memory_manager):
-        for _ in range(3):
-            assert await memory_manager.expose_service("s1", 8000) == [8000]
+    async def test_expose_is_idempotent_while_active(self, memory_manager):
+        first = await memory_manager.expose_service("s1", 8000)
+        second = await memory_manager.expose_service("s1", 8000)
+        assert second == (first[0], False)
 
     @pytest.mark.asyncio
-    async def test_expose_unknown_sandbox_returns_none(self, memory_manager):
+    async def test_reexpose_after_revoke_gets_a_new_generation(self, memory_manager):
+        first, _ = await memory_manager.expose_service("s1", 8000)
+        assert await memory_manager.revoke_service("s1", 8000) is True
+        second, created = await memory_manager.expose_service("s1", 8000)
+        assert created is True
+        assert second != first
+
+    @pytest.mark.asyncio
+    async def test_list_services(self, memory_manager):
+        await memory_manager.expose_service("s1", 8001)
+        await memory_manager.expose_service("s1", 8000)
+        assert await memory_manager.list_services("s1") == [8000, 8001]
+
+    @pytest.mark.asyncio
+    async def test_unknown_sandbox_returns_none(self, memory_manager):
         assert await memory_manager.expose_service("nope", 8000) is None
+        assert await memory_manager.list_services("nope") is None
 
     @pytest.mark.asyncio
-    async def test_expose_enforces_the_limit(self, memory_manager):
+    async def test_limit_is_enforced(self, memory_manager):
         with patch(
             "orchard_env.orchestrator.sandbox_manager.settings."
             "max_services_per_sandbox",
@@ -118,25 +75,7 @@ class TestExposeAndRevoke:
                 await memory_manager.expose_service("s1", 8002)
 
     @pytest.mark.asyncio
-    async def test_revoke_removes_the_port(self, memory_manager):
-        await memory_manager.expose_service("s1", 8000)
-        assert await memory_manager.revoke_service("s1", 8000) is True
-        assert memory_manager._sandboxes["s1"].exposed_ports == []
-
-    @pytest.mark.asyncio
-    async def test_revoking_an_unexposed_port_is_false(self, memory_manager):
-        assert await memory_manager.revoke_service("s1", 8000) is False
-
-    @pytest.mark.asyncio
-    async def test_revoke_unknown_sandbox_is_false(self, memory_manager):
-        assert await memory_manager.revoke_service("nope", 8000) is False
-
-
-class TestConcurrency:
-    """Two callers exposing different ports must not lose each other's write."""
-
-    @pytest.mark.asyncio
-    async def test_concurrent_exposes_all_land_in_memory_mode(self, memory_manager):
+    async def test_concurrent_exposes_do_not_lose_ports(self, memory_manager):
         ports = list(range(8000, 8010))
         with patch(
             "orchard_env.orchestrator.sandbox_manager.settings."
@@ -146,55 +85,22 @@ class TestConcurrency:
             await asyncio.gather(
                 *(memory_manager.expose_service("s1", port) for port in ports)
             )
-        assert sorted(memory_manager._sandboxes["s1"].exposed_ports) == ports
+        assert await memory_manager.list_services("s1") == ports
 
     @pytest.mark.asyncio
-    async def test_concurrent_exposes_all_land_with_redis(self, redis_manager):
-        ports = list(range(8000, 8010))
-        with patch(
-            "orchard_env.orchestrator.sandbox_manager.settings."
-            "max_services_per_sandbox",
-            len(ports),
-        ):
-            await asyncio.gather(
-                *(redis_manager.expose_service("s1", port) for port in ports)
-            )
-        record = json.loads(redis_manager._redis_store.data)
-        assert sorted(record["exposed_ports"]) == ports
+    async def test_delete_removes_service_state(self, memory_manager):
+        await memory_manager.expose_service("s1", 8000)
+        await memory_manager._delete_sandbox_record("s1")
+        assert "s1" not in memory_manager._services
 
     @pytest.mark.asyncio
-    async def test_concurrent_revokes_all_land_with_redis(self, redis_manager):
-        ports = list(range(8000, 8006))
-        with patch(
-            "orchard_env.orchestrator.sandbox_manager.settings."
-            "max_services_per_sandbox",
-            len(ports),
-        ):
-            for port in ports:
-                await redis_manager.expose_service("s1", port)
-
-            await asyncio.gather(
-                *(redis_manager.revoke_service("s1", port) for port in ports[:3])
-            )
-
-        record = json.loads(redis_manager._redis_store.data)
-        assert sorted(record["exposed_ports"]) == ports[3:]
-
-    @pytest.mark.asyncio
-    async def test_naive_update_would_lose_writes(self, redis_manager):
-        """Demonstrates the bug the atomic path avoids.
-
-        Using the plain last-write-wins update for the same workload drops
-        ports, which is exactly why expose/revoke do not use it.
-        """
-        store = redis_manager._redis_store
-
-        async def naive_expose(port):
-            record = await store.get_sandbox("s1")
-            exposed = list(record.get("exposed_ports") or [])
-            exposed.append(port)
-            await store.update_sandbox("s1", {"exposed_ports": exposed})
-
-        await asyncio.gather(*(naive_expose(p) for p in range(8000, 8010)))
-        record = json.loads(store.data)
-        assert len(record["exposed_ports"]) < 10
+    async def test_delete_clears_local_pod_watcher_cache(self, memory_manager):
+        watcher = MagicMock()
+        memory_manager._pod_watcher = watcher
+        await memory_manager._delete_sandbox_record("s1")
+        watcher.remove_sandbox.assert_not_called()
+        # Public deletion owns watcher cleanup because it also tears down K8s.
+        memory_manager._sandboxes["s1"] = _make_sandbox()
+        memory_manager._background_delete_k8s_resources = AsyncMock()
+        await memory_manager.delete_sandbox("s1")
+        watcher.remove_sandbox.assert_called_once_with("s1")

--- a/orchard_env/tests/test_service_endpoints.py
+++ b/orchard_env/tests/test_service_endpoints.py
@@ -1,0 +1,651 @@
+"""Route-level tests for sandbox service endpoints.
+
+These drive the real FastAPI app with a real in-process upstream server, so
+they exercise the actual proxy path: token minting, allowlist enforcement,
+header handling, streaming, and the WebSocket bridge. Only Kubernetes is
+faked — the sandbox record and pod IP are supplied directly.
+"""
+
+import gzip
+import threading
+from contextlib import ExitStack, asynccontextmanager, contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import uvicorn
+from fastapi import FastAPI, Response, WebSocket
+from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi.testclient import TestClient
+
+from orchard_env.orchestrator import service_proxy, service_tokens
+from orchard_env.orchestrator.sandbox_manager import Sandbox
+
+SANDBOX_ID = "sandbox-test"
+API_KEY = "test-api-key"
+
+
+# ---------------------------------------------------------------------------
+# A real upstream service, standing in for a server inside a sandbox
+# ---------------------------------------------------------------------------
+
+
+def _build_upstream_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    def health():
+        return {"status": "healthy"}
+
+    @app.get("/echo")
+    def echo(request_value: str = "none"):
+        return {"value": request_value}
+
+    @app.post("/body")
+    async def body(request: dict):
+        return {"received": request}
+
+    @app.get("/stream")
+    def stream():
+        def chunks():
+            for index in range(5):
+                yield f"chunk-{index};"
+
+        return StreamingResponse(chunks(), media_type="text/plain")
+
+    @app.get("/")
+    def root():
+        return PlainTextResponse("root-ok")
+
+    @app.get("/gzipped")
+    def gzipped():
+        raw = b"compressible-payload;" * 200
+        body = gzip.compress(raw)
+        return Response(
+            content=body,
+            media_type="text/plain",
+            headers={
+                "Content-Encoding": "gzip",
+                "Content-Length": str(len(body)),
+            },
+        )
+
+    @app.get("/teapot")
+    def teapot():
+        return PlainTextResponse("short and stout", status_code=418)
+
+    @app.websocket("/ws")
+    async def websocket_echo(ws: WebSocket):
+        await ws.accept()
+        try:
+            while True:
+                message = await ws.receive()
+                if message["type"] == "websocket.disconnect":
+                    break
+                if message.get("text") is not None:
+                    if message["text"] == "close-please":
+                        await ws.close(code=4200)
+                        return
+                    await ws.send_text(f"echo:{message['text']}")
+                elif message.get("bytes") is not None:
+                    await ws.send_bytes(b"bin:" + message["bytes"])
+        except Exception:
+            pass
+
+    return app
+
+
+def _ws_implementation() -> str:
+    """Pick a WebSocket server implementation uvicorn can actually use."""
+    try:
+        import websockets  # noqa: F401
+
+        return "websockets"
+    except ImportError:
+        pass
+    try:
+        import wsproto  # noqa: F401
+
+        return "wsproto"
+    except ImportError:
+        return "none"
+
+
+WS_AVAILABLE = _ws_implementation() != "none"
+requires_websockets = pytest.mark.skipif(
+    not WS_AVAILABLE,
+    reason="needs a uvicorn WebSocket implementation (websockets or wsproto)",
+)
+
+
+@contextmanager
+def running_upstream():
+    """Run the upstream app on a real loopback port."""
+    import socket
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    config = uvicorn.Config(
+        _build_upstream_app(),
+        host="127.0.0.1",
+        port=port,
+        log_level="error",
+        # Pin the WebSocket implementation instead of relying on auto-detection,
+        # so a missing `websockets` extra surfaces as an explicit skip rather
+        # than a confusing 404 on the upgrade handshake.
+        ws=_ws_implementation(),
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    import time
+
+    deadline = time.time() + 15
+    while not server.started and time.time() < deadline:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("upstream server did not start")
+
+    try:
+        yield port
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Test harness wiring the app to a fake sandbox on a real upstream port
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def orchestrator_client(upstream_port: int, exposed_ports=None, enabled=True):
+    """Yield a TestClient with the service routes wired to a fake sandbox.
+
+    The app's real lifespan builds Kubernetes and Redis clients, so it is
+    replaced with a no-op and the managers it would have created are injected
+    directly. That keeps the routes, the proxy client, and the ASGI stack real
+    while removing the cluster.
+    """
+    import orchard_env.orchestrator.api as api_module
+
+    sandbox = Sandbox(
+        sandbox_id=SANDBOX_ID,
+        namespace="sandbox-pods",
+        image="python:3.11-slim",
+        pod_name=f"sandbox-{SANDBOX_ID}",
+        block_network=True,
+        cpu="1",
+        memory="1Gi",
+        ready=True,
+        exposed_ports=list(exposed_ports if exposed_ports is not None else []),
+    )
+
+    async def fake_get_sandbox(sandbox_id):
+        return sandbox if sandbox_id == SANDBOX_ID else None
+
+    async def fake_expose(sandbox_id, port):
+        if sandbox_id != SANDBOX_ID:
+            return None
+        if port not in sandbox.exposed_ports:
+            sandbox.exposed_ports.append(port)
+        return list(sandbox.exposed_ports)
+
+    async def fake_revoke(sandbox_id, port):
+        if sandbox_id == SANDBOX_ID and port in sandbox.exposed_ports:
+            sandbox.exposed_ports.remove(port)
+            return True
+        return False
+
+    manager = AsyncMock()
+    manager.get_sandbox.side_effect = fake_get_sandbox
+    manager.expose_service.side_effect = fake_expose
+    manager.revoke_service.side_effect = fake_revoke
+    manager.get_pod_ip.return_value = "127.0.0.1"
+    manager.heartbeat.return_value = True
+
+    proxy_client = service_proxy.ServiceProxyClient()
+
+    @asynccontextmanager
+    async def noop_lifespan(_app):
+        yield
+
+    previous_lifespan = api_module.app.router.lifespan_context
+    previous_manager = getattr(api_module, "sandbox_manager", None)
+    previous_proxy = getattr(api_module, "service_proxy_client", None)
+    api_module.app.router.lifespan_context = noop_lifespan
+    api_module.sandbox_manager = manager
+    api_module.service_proxy_client = proxy_client
+
+    try:
+        patches = [
+            patch.object(api_module.settings, "enable_service_endpoints", enabled),
+            patch.object(api_module.settings, "require_api_key", True),
+            patch.object(api_module.settings, "api_keys", API_KEY),
+            patch.object(
+                service_tokens.settings, "service_token_secret", "unit-test-secret"
+            ),
+            patch.object(service_proxy.settings, "agent_port", 9090),
+        ]
+        with ExitStack() as stack:
+            for patcher in patches:
+                stack.enter_context(patcher)
+            # The upstream port must not collide with the reserved agent port.
+            assert upstream_port != 9090
+            with TestClient(api_module.app) as client:
+                try:
+                    yield client, sandbox
+                finally:
+                    # Close the pooled session on the loop that created it.
+                    client.portal.call(proxy_client.close)
+    finally:
+        api_module.app.router.lifespan_context = previous_lifespan
+        if previous_manager is not None:
+            api_module.sandbox_manager = previous_manager
+        if previous_proxy is not None:
+            api_module.service_proxy_client = previous_proxy
+
+
+@pytest.fixture
+def upstream():
+    with running_upstream() as port:
+        yield port
+
+
+AUTH = {"X-API-Key": API_KEY}
+
+
+# ---------------------------------------------------------------------------
+# Exposing and revoking
+# ---------------------------------------------------------------------------
+
+
+class TestServiceLifecycle:
+    def test_expose_returns_a_usable_url(self, upstream):
+        with orchestrator_client(upstream) as (client, sandbox):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={"port": upstream},
+                headers=AUTH,
+            )
+            assert response.status_code == 200
+            body = response.json()
+            assert body["port"] == upstream
+            assert "/s/" in body["url"]
+            assert body["expires_at"] > 0
+            assert upstream in sandbox.exposed_ports
+
+    def test_expose_requires_api_key(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services", json={"port": upstream}
+            )
+            assert response.status_code == 401
+
+    def test_expose_rejects_agent_port(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services", json={"port": 9090}, headers=AUTH
+            )
+            assert response.status_code == 400
+            assert "reserved" in response.json()["detail"]
+
+    def test_expose_unknown_sandbox_is_404(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                "/sandboxes/does-not-exist/services",
+                json={"port": upstream},
+                headers=AUTH,
+            )
+            assert response.status_code == 404
+
+    def test_expose_is_idempotent(self, upstream):
+        with orchestrator_client(upstream) as (client, sandbox):
+            for _ in range(3):
+                assert (
+                    client.post(
+                        f"/sandboxes/{SANDBOX_ID}/services",
+                        json={"port": upstream},
+                        headers=AUTH,
+                    ).status_code
+                    == 200
+                )
+            assert sandbox.exposed_ports.count(upstream) == 1
+
+    def test_list_reports_exposed_ports(self, upstream):
+        with orchestrator_client(upstream, exposed_ports=[upstream]) as (client, _):
+            response = client.get(f"/sandboxes/{SANDBOX_ID}/services", headers=AUTH)
+            assert response.status_code == 200
+            assert response.json()["ports"] == [upstream]
+
+    def test_revoke_removes_the_port(self, upstream):
+        with orchestrator_client(upstream, exposed_ports=[upstream]) as (
+            client,
+            sandbox,
+        ):
+            response = client.delete(
+                f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH
+            )
+            assert response.status_code == 200
+            assert sandbox.exposed_ports == []
+
+    def test_revoking_an_unexposed_port_is_404(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.delete(
+                f"/sandboxes/{SANDBOX_ID}/services/4321", headers=AUTH
+            )
+            assert response.status_code == 404
+
+    def test_disabled_feature_hides_the_routes(self, upstream):
+        with orchestrator_client(upstream, enabled=False) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={"port": upstream},
+                headers=AUTH,
+            )
+            assert response.status_code == 404
+            assert "disabled" in response.json()["detail"]
+
+    def test_wait_ready_polls_the_service(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={
+                    "port": upstream,
+                    "wait_ready": True,
+                    "health_path": "/health",
+                    "ready_timeout": 10,
+                },
+                headers=AUTH,
+            )
+            assert response.status_code == 200
+
+    def test_wait_ready_times_out_on_a_dead_service(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={
+                    "port": upstream,
+                    "wait_ready": True,
+                    "health_path": "/nope",
+                    "ready_timeout": 1,
+                },
+                headers=AUTH,
+            )
+            assert response.status_code == 408
+
+
+class TestServiceUrlHost:
+    """Where the URL points decides where the capability token is sent."""
+
+    def test_forwarded_host_is_ignored_by_default(self, upstream):
+        """A forged X-Forwarded-Host must not redirect the token off-site."""
+        with orchestrator_client(upstream) as (client, _):
+            response = client.post(
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={"port": upstream},
+                headers={**AUTH, "X-Forwarded-Host": "attacker.example.com"},
+            )
+            assert response.status_code == 200
+            assert "attacker.example.com" not in response.json()["url"]
+
+    def test_forwarded_host_used_only_when_trusted(self, upstream):
+        import orchard_env.orchestrator.api as api_module
+
+        with orchestrator_client(upstream) as (client, _):
+            with patch.object(
+                api_module.settings, "service_trust_forwarded_headers", True
+            ):
+                response = client.post(
+                    f"/sandboxes/{SANDBOX_ID}/services",
+                    json={"port": upstream},
+                    headers={
+                        **AUTH,
+                        "X-Forwarded-Host": "public.example.com",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+            assert response.json()["url"].startswith("https://public.example.com/s/")
+
+    def test_configured_base_url_wins(self, upstream):
+        """An explicit base URL is authoritative, whatever headers claim."""
+        import orchard_env.orchestrator.api as api_module
+
+        with orchestrator_client(upstream) as (client, _):
+            with ExitStack() as stack:
+                stack.enter_context(
+                    patch.object(
+                        api_module.settings,
+                        "service_public_base_url",
+                        "https://orchard.example.com",
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        api_module.settings, "service_trust_forwarded_headers", True
+                    )
+                )
+                response = client.post(
+                    f"/sandboxes/{SANDBOX_ID}/services",
+                    json={"port": upstream},
+                    headers={**AUTH, "X-Forwarded-Host": "attacker.example.com"},
+                )
+            url = response.json()["url"]
+            assert url.startswith("https://orchard.example.com/s/")
+            assert "attacker.example.com" not in url
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxying
+# ---------------------------------------------------------------------------
+
+
+def _expose(client, port) -> str:
+    response = client.post(
+        f"/sandboxes/{SANDBOX_ID}/services", json={"port": port}, headers=AUTH
+    )
+    assert response.status_code == 200
+    # TestClient URLs are absolute; keep only the path so the request routes.
+    return "/s/" + response.json()["url"].split("/s/", 1)[1]
+
+
+class TestHttpProxy:
+    def test_get_is_proxied(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.get(f"{base}/health")
+            assert response.status_code == 200
+            assert response.json() == {"status": "healthy"}
+
+    def test_proxy_needs_no_api_key(self, upstream):
+        """The URL is the credential; header-less clients must work."""
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            assert client.get(f"{base}/health").status_code == 200
+
+    def test_query_string_reaches_upstream(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.get(f"{base}/echo?request_value=hello")
+            assert response.json() == {"value": "hello"}
+
+    def test_post_body_reaches_upstream(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.post(f"{base}/body", json={"a": 1})
+            assert response.json() == {"received": {"a": 1}}
+
+    def test_upstream_status_is_preserved(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.get(f"{base}/teapot")
+            assert response.status_code == 418
+            assert response.text == "short and stout"
+
+    def test_streaming_response_is_complete(self, upstream):
+        """Regression guard: mis-copied framing headers truncate the body."""
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.get(f"{base}/stream")
+            assert response.status_code == 200
+            assert response.text == "chunk-0;chunk-1;chunk-2;chunk-3;chunk-4;"
+
+    def test_unknown_upstream_path_yields_upstream_404(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            assert client.get(f"{base}/missing").status_code == 404
+
+    def test_compressed_response_is_still_decodable(self, upstream):
+        """Regression guard: the body is relayed as-is, so Content-Encoding
+        must survive. Stripping it while forwarding gzipped bytes hands the
+        client undecodable data."""
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            response = client.get(f"{base}/gzipped")
+            assert response.status_code == 200
+            assert response.text == "compressible-payload;" * 200
+
+    def test_root_of_the_service_url_is_reachable(self, upstream):
+        """A bare `curl $URL` must work, not just paths beneath it."""
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            assert client.get(base).text == "root-ok"
+            assert client.get(f"{base}/").text == "root-ok"
+
+    def test_unreachable_service_does_not_leak_the_pod_ip(self, upstream):
+        """A 502 must not tell an external caller the cluster's internals."""
+        import socket
+
+        # A port nothing is listening on, so a real connection error occurs.
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            dead_port = probe.getsockname()[1]
+
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, dead_port)
+            response = client.get(f"{base}/health")
+
+            assert response.status_code == 502
+            detail = response.json()["detail"]
+            assert detail == "Service unreachable"
+            assert "127.0.0.1" not in detail
+            assert str(dead_port) not in detail
+
+
+# ---------------------------------------------------------------------------
+# Authorisation on the proxy path
+# ---------------------------------------------------------------------------
+
+
+class TestProxyAuthorisation:
+    def test_forged_token_rejected(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            _expose(client, upstream)
+            assert client.get("/s/not-a-real-token/health").status_code == 403
+
+    def test_token_for_an_unexposed_port_rejected(self, upstream):
+        """A token alone is not enough; the port must still be allowlisted."""
+        with orchestrator_client(upstream) as (client, _):
+            token, _expiry = service_tokens.mint_token(SANDBOX_ID, upstream)
+            assert client.get(f"/s/{token}/health").status_code == 403
+
+    def test_revocation_takes_effect_immediately(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            assert client.get(f"{base}/health").status_code == 200
+
+            assert (
+                client.delete(
+                    f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH
+                ).status_code
+                == 200
+            )
+            # Same, still-unexpired URL must now be refused.
+            assert client.get(f"{base}/health").status_code == 403
+
+    def test_expired_token_rejected(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            import time as time_module
+
+            with patch.object(
+                service_tokens.time, "time", return_value=time_module.time() + 86400
+            ):
+                assert client.get(f"{base}/health").status_code == 403
+
+    def test_proxy_disabled_when_feature_off(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+        with orchestrator_client(upstream, exposed_ports=[upstream], enabled=False) as (
+            client2,
+            _,
+        ):
+            assert client2.get(f"{base}/health").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxying — the reason the capability URL exists
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketProxy:
+    @requires_websockets
+    def test_text_frames_round_trip(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            with client.websocket_connect(f"{base}/ws") as ws:
+                ws.send_text("hello")
+                assert ws.receive_text() == "echo:hello"
+
+    @requires_websockets
+    def test_many_frames_round_trip(self, upstream):
+        """A persistent session, which is how an RL rollout drives an env."""
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            with client.websocket_connect(f"{base}/ws") as ws:
+                for index in range(25):
+                    ws.send_text(f"m{index}")
+                    assert ws.receive_text() == f"echo:m{index}"
+
+    @requires_websockets
+    def test_binary_frames_round_trip(self, upstream):
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            with client.websocket_connect(f"{base}/ws") as ws:
+                ws.send_bytes(b"\x00\x01\x02")
+                assert ws.receive_bytes() == b"bin:\x00\x01\x02"
+
+    @requires_websockets
+    def test_upstream_close_code_is_propagated(self, upstream):
+        """A client must be able to tell a clean close from a proxy failure."""
+        from starlette.websockets import WebSocketDisconnect
+
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            with client.websocket_connect(f"{base}/ws") as ws:
+                ws.send_text("close-please")
+                with pytest.raises(WebSocketDisconnect) as excinfo:
+                    ws.receive_text()
+            assert excinfo.value.code == 4200
+
+    def test_forged_token_refused_before_accept(self, upstream):
+        from starlette.websockets import WebSocketDisconnect
+
+        with orchestrator_client(upstream) as (client, _):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                with client.websocket_connect("/s/bogus-token/ws"):
+                    pass
+            assert excinfo.value.code == 4403
+
+    def test_revoked_port_refuses_new_sockets(self, upstream):
+        from starlette.websockets import WebSocketDisconnect
+
+        with orchestrator_client(upstream) as (client, _):
+            base = _expose(client, upstream)
+            client.delete(f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH)
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                with client.websocket_connect(f"{base}/ws"):
+                    pass
+            assert excinfo.value.code == 4403

--- a/orchard_env/tests/test_service_endpoints.py
+++ b/orchard_env/tests/test_service_endpoints.py
@@ -1,39 +1,46 @@
-"""Route-level tests for sandbox service endpoints.
+"""End-to-end route tests for sandbox service endpoints.
 
-These drive the real FastAPI app with a real in-process upstream server, so
-they exercise the actual proxy path: token minting, allowlist enforcement,
-header handling, streaming, and the WebSocket bridge. Only Kubernetes is
-faked — the sandbox record and pod IP are supplied directly.
+The orchestrator app and proxy are real. Only Kubernetes-backed sandbox lookup
+is replaced with a small in-memory manager.
 """
 
+import asyncio
 import gzip
+import socket
 import threading
+import time
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import uvicorn
-from fastapi import FastAPI, Response, WebSocket
-from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi import FastAPI, Request, Response, WebSocket
+from fastapi.responses import (
+    PlainTextResponse,
+    RedirectResponse,
+    StreamingResponse,
+)
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from orchard_env.orchestrator import service_proxy, service_tokens
 from orchard_env.orchestrator.sandbox_manager import Sandbox
 
 SANDBOX_ID = "sandbox-test"
 API_KEY = "test-api-key"
+SERVICE_ORIGIN_TEMPLATE = "http://{subdomain}.services.testserver"
+AUTH = {"X-API-Key": API_KEY}
 
 
-# ---------------------------------------------------------------------------
-# A real upstream service, standing in for a server inside a sandbox
-# ---------------------------------------------------------------------------
-
-
-def _build_upstream_app() -> FastAPI:
+def _build_upstream_app(redirect_target: str | None = None) -> FastAPI:
     app = FastAPI()
+    app.state.hits = 0
+    app.state.ws_hits = 0
+    app.state.last_protocols = ""
 
     @app.get("/health")
     def health():
+        app.state.hits += 1
         return {"status": "healthy"}
 
     @app.get("/echo")
@@ -41,14 +48,21 @@ def _build_upstream_app() -> FastAPI:
         return {"value": request_value}
 
     @app.post("/body")
-    async def body(request: dict):
-        return {"received": request}
+    async def body(request: Request):
+        return Response(await request.body(), media_type="application/octet-stream")
 
     @app.get("/stream")
     def stream():
-        def chunks():
-            for index in range(5):
-                yield f"chunk-{index};"
+        return StreamingResponse(
+            (f"chunk-{index};" for index in range(5)), media_type="text/plain"
+        )
+
+    @app.get("/slow-stream")
+    async def slow_stream():
+        async def chunks():
+            yield "start;"
+            await asyncio.sleep(0.12)
+            yield "end;"
 
         return StreamingResponse(chunks(), media_type="text/plain")
 
@@ -59,13 +73,13 @@ def _build_upstream_app() -> FastAPI:
     @app.get("/gzipped")
     def gzipped():
         raw = b"compressible-payload;" * 200
-        body = gzip.compress(raw)
+        compressed = gzip.compress(raw)
         return Response(
-            content=body,
+            content=compressed,
             media_type="text/plain",
             headers={
                 "Content-Encoding": "gzip",
-                "Content-Length": str(len(body)),
+                "Content-Length": str(len(compressed)),
             },
         )
 
@@ -73,9 +87,59 @@ def _build_upstream_app() -> FastAPI:
     def teapot():
         return PlainTextResponse("short and stout", status_code=418)
 
+    @app.get("/request-headers")
+    def request_headers(request: Request):
+        return {
+            "authorization": request.headers.get("authorization"),
+            "cookie": request.headers.get("cookie"),
+            "x_api_key": request.headers.get("x-api-key"),
+            "x_custom": request.headers.get("x-custom"),
+        }
+
+    @app.get("/response-headers")
+    def response_headers():
+        response = PlainTextResponse("headers")
+        response.raw_headers.extend(
+            [
+                (b"x-repeat", b"one"),
+                (b"x-repeat", b"two"),
+                (b"set-cookie", b"hostile=1; Domain=.example.com"),
+                (b"service-worker-allowed", b"/"),
+            ]
+        )
+        return response
+
+    @app.api_route("/raw/{rest:path}", methods=["GET", "POST"])
+    async def raw_path(request: Request, rest: str):
+        return {
+            "raw_path": request.scope["raw_path"].decode("ascii"),
+            "raw_query": request.scope["query_string"].decode("ascii"),
+        }
+
+    @app.get("/redirect-health")
+    def redirect_health():
+        return RedirectResponse(f"{redirect_target}/health")
+
+    @app.get("/relative-redirect")
+    def relative_redirect():
+        return RedirectResponse("/health")
+
+    @app.get("/ws-redirect")
+    def ws_redirect():
+        return RedirectResponse(f"{redirect_target.replace('http:', 'ws:')}/ws")
+
+    @app.get("/ws-hang")
+    async def ws_hang():
+        await asyncio.sleep(1)
+        return PlainTextResponse("too late")
+
     @app.websocket("/ws")
     async def websocket_echo(ws: WebSocket):
-        await ws.accept()
+        app.state.ws_hits += 1
+        offered = ws.headers.get("sec-websocket-protocol", "")
+        app.state.last_protocols = offered
+        subprotocol = "openenv-v1" if "openenv-v1" in offered else None
+        await ws.accept(subprotocol=subprotocol)
         try:
             while True:
                 message = await ws.receive()
@@ -85,6 +149,8 @@ def _build_upstream_app() -> FastAPI:
                     if message["text"] == "close-please":
                         await ws.close(code=4200)
                         return
+                    if message["text"] == "wait":
+                        await asyncio.sleep(0.12)
                     await ws.send_text(f"echo:{message['text']}")
                 elif message.get("bytes") is not None:
                     await ws.send_bytes(b"bin:" + message["bytes"])
@@ -95,7 +161,6 @@ def _build_upstream_app() -> FastAPI:
 
 
 def _ws_implementation() -> str:
-    """Pick a WebSocket server implementation uvicorn can actually use."""
     try:
         import websockets  # noqa: F401
 
@@ -113,62 +178,42 @@ def _ws_implementation() -> str:
 WS_AVAILABLE = _ws_implementation() != "none"
 requires_websockets = pytest.mark.skipif(
     not WS_AVAILABLE,
-    reason="needs a uvicorn WebSocket implementation (websockets or wsproto)",
+    reason="needs a uvicorn WebSocket implementation",
 )
 
 
 @contextmanager
-def running_upstream():
-    """Run the upstream app on a real loopback port."""
-    import socket
-
+def running_upstream(app: FastAPI | None = None):
     with socket.socket() as probe:
         probe.bind(("127.0.0.1", 0))
         port = probe.getsockname()[1]
 
-    config = uvicorn.Config(
-        _build_upstream_app(),
-        host="127.0.0.1",
-        port=port,
-        log_level="error",
-        # Pin the WebSocket implementation instead of relying on auto-detection,
-        # so a missing `websockets` extra surfaces as an explicit skip rather
-        # than a confusing 404 on the upgrade handshake.
-        ws=_ws_implementation(),
+    app = app or _build_upstream_app()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="error",
+            ws=_ws_implementation(),
+        )
     )
-    server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
-
-    import time
-
     deadline = time.time() + 15
     while not server.started and time.time() < deadline:
         time.sleep(0.05)
     if not server.started:
         raise RuntimeError("upstream server did not start")
-
     try:
-        yield port
+        yield port, app
     finally:
         server.should_exit = True
         thread.join(timeout=10)
 
 
-# ---------------------------------------------------------------------------
-# Test harness wiring the app to a fake sandbox on a real upstream port
-# ---------------------------------------------------------------------------
-
-
 @contextmanager
-def orchestrator_client(upstream_port: int, exposed_ports=None, enabled=True):
-    """Yield a TestClient with the service routes wired to a fake sandbox.
-
-    The app's real lifespan builds Kubernetes and Redis clients, so it is
-    replaced with a no-op and the managers it would have created are injected
-    directly. That keeps the routes, the proxy client, and the ASGI stack real
-    while removing the cluster.
-    """
+def orchestrator_client(upstream_port: int, enabled: bool = True):
     import orchard_env.orchestrator.api as api_module
 
     sandbox = Sandbox(
@@ -180,30 +225,42 @@ def orchestrator_client(upstream_port: int, exposed_ports=None, enabled=True):
         cpu="1",
         memory="1Gi",
         ready=True,
-        exposed_ports=list(exposed_ports if exposed_ports is not None else []),
     )
+    services: dict[int, str] = {}
+    generation_counter = 0
 
     async def fake_get_sandbox(sandbox_id):
         return sandbox if sandbox_id == SANDBOX_ID else None
 
     async def fake_expose(sandbox_id, port):
+        nonlocal generation_counter
         if sandbox_id != SANDBOX_ID:
             return None
-        if port not in sandbox.exposed_ports:
-            sandbox.exposed_ports.append(port)
-        return list(sandbox.exposed_ports)
+        if port in services:
+            return services[port], False
+        generation_counter += 1
+        services[port] = f"generation-{generation_counter}"
+        return services[port], True
 
     async def fake_revoke(sandbox_id, port):
-        if sandbox_id == SANDBOX_ID and port in sandbox.exposed_ports:
-            sandbox.exposed_ports.remove(port)
-            return True
-        return False
+        return (
+            services.pop(port, None) is not None if sandbox_id == SANDBOX_ID else False
+        )
+
+    async def fake_list(sandbox_id):
+        return sorted(services) if sandbox_id == SANDBOX_ID else None
+
+    async def fake_generation(sandbox_id, port):
+        return services.get(port) if sandbox_id == SANDBOX_ID else None
 
     manager = AsyncMock()
     manager.get_sandbox.side_effect = fake_get_sandbox
     manager.expose_service.side_effect = fake_expose
     manager.revoke_service.side_effect = fake_revoke
+    manager.list_services.side_effect = fake_list
+    manager.get_service_generation.side_effect = fake_generation
     manager.get_pod_ip.return_value = "127.0.0.1"
+    manager.get_current_pod_ip.return_value = "127.0.0.1"
     manager.heartbeat.return_value = True
 
     proxy_client = service_proxy.ServiceProxyClient()
@@ -219,26 +276,31 @@ def orchestrator_client(upstream_port: int, exposed_ports=None, enabled=True):
     api_module.sandbox_manager = manager
     api_module.service_proxy_client = proxy_client
 
+    patches = [
+        patch.object(api_module.settings, "enable_service_endpoints", enabled),
+        patch.object(api_module.settings, "require_api_key", True),
+        patch.object(api_module.settings, "api_keys", API_KEY),
+        patch.object(
+            api_module.settings,
+            "service_public_base_url",
+            SERVICE_ORIGIN_TEMPLATE,
+        ),
+        patch.object(api_module.settings, "service_allow_insecure_http", True),
+        patch.object(api_module.settings, "service_token_secret", "test-secret"),
+        patch.object(
+            api_module.settings, "service_active_heartbeat_interval_seconds", 0.02
+        ),
+        patch.object(service_proxy.settings, "agent_port", 9090),
+    ]
     try:
-        patches = [
-            patch.object(api_module.settings, "enable_service_endpoints", enabled),
-            patch.object(api_module.settings, "require_api_key", True),
-            patch.object(api_module.settings, "api_keys", API_KEY),
-            patch.object(
-                service_tokens.settings, "service_token_secret", "unit-test-secret"
-            ),
-            patch.object(service_proxy.settings, "agent_port", 9090),
-        ]
         with ExitStack() as stack:
             for patcher in patches:
                 stack.enter_context(patcher)
-            # The upstream port must not collide with the reserved agent port.
             assert upstream_port != 9090
             with TestClient(api_module.app) as client:
                 try:
-                    yield client, sandbox
+                    yield client, services, manager
                 finally:
-                    # Close the pooled session on the loop that created it.
                     client.portal.call(proxy_client.close)
     finally:
         api_module.app.router.lifespan_context = previous_lifespan
@@ -250,402 +312,435 @@ def orchestrator_client(upstream_port: int, exposed_ports=None, enabled=True):
 
 @pytest.fixture
 def upstream():
-    with running_upstream() as port:
-        yield port
+    with running_upstream() as value:
+        yield value
 
 
-AUTH = {"X-API-Key": API_KEY}
-
-
-# ---------------------------------------------------------------------------
-# Exposing and revoking
-# ---------------------------------------------------------------------------
+def _expose(client: TestClient, port: int, **overrides) -> str:
+    response = client.post(
+        f"/sandboxes/{SANDBOX_ID}/services",
+        json={"port": port, **overrides},
+        headers=AUTH,
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["url"]
 
 
 class TestServiceLifecycle:
-    def test_expose_returns_a_usable_url(self, upstream):
-        with orchestrator_client(upstream) as (client, sandbox):
-            response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services",
-                json={"port": upstream},
-                headers=AUTH,
+    def test_expose_list_and_revoke(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, services, _manager):
+            url = _expose(client, port)
+            assert ".services.testserver/s/" in url
+            assert client.get(f"/sandboxes/{SANDBOX_ID}/services", headers=AUTH).json()[
+                "ports"
+            ] == [port]
+            assert (
+                client.delete(
+                    f"/sandboxes/{SANDBOX_ID}/services/{port}", headers=AUTH
+                ).status_code
+                == 200
             )
-            assert response.status_code == 200
-            body = response.json()
-            assert body["port"] == upstream
-            assert "/s/" in body["url"]
-            assert body["expires_at"] > 0
-            assert upstream in sandbox.exposed_ports
+            assert services == {}
 
-    def test_expose_requires_api_key(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
+    def test_expose_requires_management_api_key(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
             response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services", json={"port": upstream}
+                f"/sandboxes/{SANDBOX_ID}/services", json={"port": port}
             )
             assert response.status_code == 401
 
-    def test_expose_rejects_agent_port(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
+    def test_agent_port_is_rejected(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
             response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services", json={"port": 9090}, headers=AUTH
+                f"/sandboxes/{SANDBOX_ID}/services",
+                json={"port": 9090},
+                headers=AUTH,
             )
             assert response.status_code == 400
-            assert "reserved" in response.json()["detail"]
 
-    def test_expose_unknown_sandbox_is_404(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            response = client.post(
-                "/sandboxes/does-not-exist/services",
-                json={"port": upstream},
-                headers=AUTH,
-            )
-            assert response.status_code == 404
-
-    def test_expose_is_idempotent(self, upstream):
-        with orchestrator_client(upstream) as (client, sandbox):
-            for _ in range(3):
-                assert (
-                    client.post(
-                        f"/sandboxes/{SANDBOX_ID}/services",
-                        json={"port": upstream},
-                        headers=AUTH,
-                    ).status_code
-                    == 200
-                )
-            assert sandbox.exposed_ports.count(upstream) == 1
-
-    def test_list_reports_exposed_ports(self, upstream):
-        with orchestrator_client(upstream, exposed_ports=[upstream]) as (client, _):
-            response = client.get(f"/sandboxes/{SANDBOX_ID}/services", headers=AUTH)
-            assert response.status_code == 200
-            assert response.json()["ports"] == [upstream]
-
-    def test_revoke_removes_the_port(self, upstream):
-        with orchestrator_client(upstream, exposed_ports=[upstream]) as (
-            client,
-            sandbox,
-        ):
-            response = client.delete(
-                f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH
-            )
-            assert response.status_code == 200
-            assert sandbox.exposed_ports == []
-
-    def test_revoking_an_unexposed_port_is_404(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            response = client.delete(
-                f"/sandboxes/{SANDBOX_ID}/services/4321", headers=AUTH
-            )
-            assert response.status_code == 404
-
-    def test_disabled_feature_hides_the_routes(self, upstream):
-        with orchestrator_client(upstream, enabled=False) as (client, _):
-            response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services",
-                json={"port": upstream},
-                headers=AUTH,
-            )
-            assert response.status_code == 404
-            assert "disabled" in response.json()["detail"]
-
-    def test_wait_ready_polls_the_service(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
+    def test_readiness_failure_does_not_create_exposure(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, services, _manager):
             response = client.post(
                 f"/sandboxes/{SANDBOX_ID}/services",
                 json={
-                    "port": upstream,
+                    "port": port,
                     "wait_ready": True,
-                    "health_path": "/health",
-                    "ready_timeout": 10,
-                },
-                headers=AUTH,
-            )
-            assert response.status_code == 200
-
-    def test_wait_ready_times_out_on_a_dead_service(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services",
-                json={
-                    "port": upstream,
-                    "wait_ready": True,
-                    "health_path": "/nope",
+                    "health_path": "/missing",
                     "ready_timeout": 1,
                 },
                 headers=AUTH,
             )
             assert response.status_code == 408
+            assert services == {}
 
-
-class TestServiceUrlHost:
-    """Where the URL points decides where the capability token is sent."""
-
-    def test_forwarded_host_is_ignored_by_default(self, upstream):
-        """A forged X-Forwarded-Host must not redirect the token off-site."""
-        with orchestrator_client(upstream) as (client, _):
-            response = client.post(
-                f"/sandboxes/{SANDBOX_ID}/services",
-                json={"port": upstream},
-                headers={**AUTH, "X-Forwarded-Host": "attacker.example.com"},
-            )
-            assert response.status_code == 200
-            assert "attacker.example.com" not in response.json()["url"]
-
-    def test_forwarded_host_used_only_when_trusted(self, upstream):
+    def test_missing_base_url_fails_closed(self, upstream):
         import orchard_env.orchestrator.api as api_module
 
-        with orchestrator_client(upstream) as (client, _):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            with patch.object(api_module.settings, "service_public_base_url", None):
+                response = client.post(
+                    f"/sandboxes/{SANDBOX_ID}/services",
+                    json={"port": port},
+                    headers=AUTH,
+                )
+            assert response.status_code == 503
+
+    def test_insecure_public_url_requires_explicit_opt_in(self, upstream):
+        import orchard_env.orchestrator.api as api_module
+
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
             with patch.object(
-                api_module.settings, "service_trust_forwarded_headers", True
+                api_module.settings, "service_allow_insecure_http", False
             ):
                 response = client.post(
                     f"/sandboxes/{SANDBOX_ID}/services",
-                    json={"port": upstream},
-                    headers={
-                        **AUTH,
-                        "X-Forwarded-Host": "public.example.com",
-                        "X-Forwarded-Proto": "https",
-                    },
+                    json={"port": port},
+                    headers=AUTH,
                 )
-            assert response.json()["url"].startswith("https://public.example.com/s/")
-
-    def test_configured_base_url_wins(self, upstream):
-        """An explicit base URL is authoritative, whatever headers claim."""
-        import orchard_env.orchestrator.api as api_module
-
-        with orchestrator_client(upstream) as (client, _):
-            with ExitStack() as stack:
-                stack.enter_context(
-                    patch.object(
-                        api_module.settings,
-                        "service_public_base_url",
-                        "https://orchard.example.com",
-                    )
-                )
-                stack.enter_context(
-                    patch.object(
-                        api_module.settings, "service_trust_forwarded_headers", True
-                    )
-                )
-                response = client.post(
-                    f"/sandboxes/{SANDBOX_ID}/services",
-                    json={"port": upstream},
-                    headers={**AUTH, "X-Forwarded-Host": "attacker.example.com"},
-                )
-            url = response.json()["url"]
-            assert url.startswith("https://orchard.example.com/s/")
-            assert "attacker.example.com" not in url
+            assert response.status_code == 503
 
 
-# ---------------------------------------------------------------------------
-# HTTP proxying
-# ---------------------------------------------------------------------------
+class TestOriginIsolation:
+    def test_capabilities_receive_different_browser_origins(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            first = _expose(client, port).split("/s/", 1)[0]
+            second = _expose(client, port + 1).split("/s/", 1)[0]
+            assert first != second
 
+    def test_proxy_is_refused_on_management_origin(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            url = _expose(client, port)
+            path = "/" + url.split("/", 3)[3]
+            assert client.get(path).status_code == 404
 
-def _expose(client, port) -> str:
-    response = client.post(
-        f"/sandboxes/{SANDBOX_ID}/services", json={"port": port}, headers=AUTH
-    )
-    assert response.status_code == 200
-    # TestClient URLs are absolute; keep only the path so the request routes.
-    return "/s/" + response.json()["url"].split("/s/", 1)[1]
+    def test_management_api_is_refused_on_service_origin(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            service_origin = _expose(client, port).split("/s/", 1)[0]
+            response = client.get(f"{service_origin}/health")
+            assert response.status_code == 404
+
+    def test_same_hostname_on_another_port_is_not_a_management_origin(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            service_origin = _expose(client, port).split("/s/", 1)[0]
+            hostname = service_origin.split("://", 1)[1]
+            response = client.get(f"http://{hostname}:9999/health")
+            assert response.status_code == 404
 
 
 class TestHttpProxy:
-    def test_get_is_proxied(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.get(f"{base}/health")
-            assert response.status_code == 200
-            assert response.json() == {"status": "healthy"}
+    def test_status_query_body_stream_and_compression(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            assert client.get(f"{base}/health").json() == {"status": "healthy"}
+            assert client.get(f"{base}/echo?request_value=hello").json() == {
+                "value": "hello"
+            }
+            assert client.post(f"{base}/body", content=b"payload").content == b"payload"
+            assert client.get(f"{base}/teapot").status_code == 418
+            assert client.get(f"{base}/stream").text == (
+                "chunk-0;chunk-1;chunk-2;chunk-3;chunk-4;"
+            )
+            root = client.get(base, follow_redirects=False)
+            assert root.status_code == 200
+            assert root.text == "root-ok"
+            assert client.get(f"{base}/gzipped").text == ("compressible-payload;" * 200)
 
-    def test_proxy_needs_no_api_key(self, upstream):
-        """The URL is the credential; header-less clients must work."""
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            assert client.get(f"{base}/health").status_code == 200
+    def test_management_credentials_are_not_forwarded(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            response = client.get(
+                f"{base}/request-headers",
+                headers={
+                    "Authorization": "Bearer secret",
+                    "Cookie": "session=secret",
+                    "X-API-Key": "management-key",
+                    "X-Custom": "safe",
+                },
+            )
+            assert response.json() == {
+                "authorization": None,
+                "cookie": None,
+                "x_api_key": None,
+                "x_custom": "safe",
+            }
 
-    def test_query_string_reaches_upstream(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.get(f"{base}/echo?request_value=hello")
-            assert response.json() == {"value": "hello"}
+    def test_hostile_browser_state_headers_are_stripped(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            response = client.get(f"{_expose(client, port)}/response-headers")
+            assert "set-cookie" not in response.headers
+            assert "service-worker-allowed" not in response.headers
+            assert response.headers.get("x-repeat") == "one, two"
 
-    def test_post_body_reaches_upstream(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.post(f"{base}/body", json={"a": 1})
-            assert response.json() == {"received": {"a": 1}}
+    def test_encoded_path_and_query_are_preserved(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            response = client.get(f"{base}/raw/a%2Fb%3Fc%23d?sig=a%2Fb%3Fc%23d")
+            assert response.json() == {
+                "raw_path": "/raw/a%2Fb%3Fc%23d",
+                "raw_query": "sig=a%2Fb%3Fc%23d",
+            }
 
-    def test_upstream_status_is_preserved(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.get(f"{base}/teapot")
-            assert response.status_code == 418
-            assert response.text == "short and stout"
+    def test_management_api_key_is_removed_from_query(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            response = client.get(f"{base}/raw/value?api_key={API_KEY}&sig=a%2Fb")
+            assert response.json()["raw_query"] == "sig=a%2Fb"
 
-    def test_streaming_response_is_complete(self, upstream):
-        """Regression guard: mis-copied framing headers truncate the body."""
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.get(f"{base}/stream")
-            assert response.status_code == 200
-            assert response.text == "chunk-0;chunk-1;chunk-2;chunk-3;chunk-4;"
+    def test_request_size_limit(self, upstream):
+        import orchard_env.orchestrator.api as api_module
 
-    def test_unknown_upstream_path_yields_upstream_404(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            assert client.get(f"{base}/missing").status_code == 404
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            with patch.object(
+                api_module.settings, "service_proxy_max_request_bytes", 4
+            ):
+                response = client.post(f"{base}/body", content=b"12345")
+            assert response.status_code == 413
 
-    def test_compressed_response_is_still_decodable(self, upstream):
-        """Regression guard: the body is relayed as-is, so Content-Encoding
-        must survive. Stripping it while forwarding gzipped bytes hands the
-        client undecodable data."""
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            response = client.get(f"{base}/gzipped")
-            assert response.status_code == 200
-            assert response.text == "compressible-payload;" * 200
+    def test_chunked_request_size_limit(self, upstream):
+        import orchard_env.orchestrator.api as api_module
 
-    def test_root_of_the_service_url_is_reachable(self, upstream):
-        """A bare `curl $URL` must work, not just paths beneath it."""
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            assert client.get(base).text == "root-ok"
-            assert client.get(f"{base}/").text == "root-ok"
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port)
+            with patch.object(
+                api_module.settings, "service_proxy_max_request_bytes", 4
+            ):
+                response = client.post(f"{base}/body", content=iter([b"12", b"345"]))
+            assert response.status_code == 413
 
-    def test_unreachable_service_does_not_leak_the_pod_ip(self, upstream):
-        """A 502 must not tell an external caller the cluster's internals."""
-        import socket
+    def test_active_stream_refreshes_heartbeat(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, manager):
+            base = _expose(client, port)
+            assert client.get(f"{base}/slow-stream").text == "start;end;"
+            # One initial refresh plus at least one active-session refresh.
+            assert manager.heartbeat.await_count >= 2
 
-        # A port nothing is listening on, so a real connection error occurs.
+    def test_upstream_error_does_not_leak_pod_address(self, upstream):
+        port, _app = upstream
         with socket.socket() as probe:
             probe.bind(("127.0.0.1", 0))
             dead_port = probe.getsockname()[1]
-
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, dead_port)
-            response = client.get(f"{base}/health")
-
+        with orchestrator_client(port) as (client, _services, _manager):
+            response = client.get(f"{_expose(client, dead_port)}/health")
             assert response.status_code == 502
-            detail = response.json()["detail"]
-            assert detail == "Service unreachable"
-            assert "127.0.0.1" not in detail
-            assert str(dead_port) not in detail
+            assert response.json()["detail"] == "Service unreachable"
+            assert str(dead_port) not in response.text
 
 
-# ---------------------------------------------------------------------------
-# Authorisation on the proxy path
-# ---------------------------------------------------------------------------
-
-
-class TestProxyAuthorisation:
-    def test_forged_token_rejected(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            _expose(client, upstream)
-            assert client.get("/s/not-a-real-token/health").status_code == 403
-
-    def test_token_for_an_unexposed_port_rejected(self, upstream):
-        """A token alone is not enough; the port must still be allowlisted."""
-        with orchestrator_client(upstream) as (client, _):
-            token, _expiry = service_tokens.mint_token(SANDBOX_ID, upstream)
-            assert client.get(f"/s/{token}/health").status_code == 403
-
-    def test_revocation_takes_effect_immediately(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            assert client.get(f"{base}/health").status_code == 200
-
-            assert (
-                client.delete(
-                    f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH
-                ).status_code
-                == 200
+class TestCapabilities:
+    def test_forged_and_unexposed_tokens_are_rejected(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            forged_url = service_proxy.build_service_url(
+                SERVICE_ORIGIN_TEMPLATE, "not-a-real-token"
             )
-            # Same, still-unexpired URL must now be refused.
-            assert client.get(f"{base}/health").status_code == 403
+            assert client.get(f"{forged_url}/health").status_code == 403
+            token, _ = service_tokens.mint_token(SANDBOX_ID, port, "not-active")
+            unexposed_url = service_proxy.build_service_url(
+                SERVICE_ORIGIN_TEMPLATE, token
+            )
+            assert client.get(f"{unexposed_url}/health").status_code == 403
 
-    def test_expired_token_rejected(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            import time as time_module
+    def test_revoke_then_reexpose_does_not_revive_old_url(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            old_url = _expose(client, port)
+            assert client.get(f"{old_url}/health").status_code == 200
+            client.delete(f"/sandboxes/{SANDBOX_ID}/services/{port}", headers=AUTH)
+            new_url = _expose(client, port)
+            assert new_url != old_url
+            assert client.get(f"{old_url}/health").status_code == 403
+            assert client.get(f"{new_url}/health").status_code == 200
 
-            with patch.object(
-                service_tokens.time, "time", return_value=time_module.time() + 86400
-            ):
-                assert client.get(f"{base}/health").status_code == 403
 
-    def test_proxy_disabled_when_feature_off(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-        with orchestrator_client(upstream, exposed_ports=[upstream], enabled=False) as (
-            client2,
-            _,
+class TestSessionWatchdog:
+    @pytest.mark.asyncio
+    async def test_revocation_closes_an_active_session(self):
+        import orchard_env.orchestrator.api as api_module
+
+        manager = AsyncMock()
+        manager.get_service_generation.return_value = None
+        close = AsyncMock()
+        with (
+            patch.object(api_module, "sandbox_manager", manager),
+            patch.object(
+                api_module.settings, "service_active_heartbeat_interval_seconds", 0.01
+            ),
         ):
-            assert client2.get(f"{base}/health").status_code == 404
+            await asyncio.wait_for(
+                api_module._maintain_service_session(
+                    SANDBOX_ID,
+                    8000,
+                    "generation",
+                    int(time.time()) + 60,
+                    close_session=close,
+                ),
+                timeout=0.2,
+            )
+        close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_state_store_failure_closes_an_active_session(self):
+        import orchard_env.orchestrator.api as api_module
+
+        manager = AsyncMock()
+        manager.get_service_generation.side_effect = RuntimeError("redis unavailable")
+        close = AsyncMock()
+        with (
+            patch.object(api_module, "sandbox_manager", manager),
+            patch.object(
+                api_module.settings, "service_active_heartbeat_interval_seconds", 0.01
+            ),
+        ):
+            await asyncio.wait_for(
+                api_module._maintain_service_session(
+                    SANDBOX_ID,
+                    8000,
+                    "generation",
+                    int(time.time()) + 60,
+                    close_session=close,
+                ),
+                timeout=0.2,
+            )
+        close.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
-# WebSocket proxying — the reason the capability URL exists
-# ---------------------------------------------------------------------------
+class TestRedirectPinning:
+    def test_external_http_redirect_is_blocked(self):
+        victim = _build_upstream_app()
+        with running_upstream(victim) as (victim_port, victim_app):
+            target = f"http://127.0.0.1:{victim_port}"
+            primary = _build_upstream_app(target)
+            with running_upstream(primary) as (primary_port, _primary_app):
+                with orchestrator_client(primary_port) as (
+                    client,
+                    _services,
+                    _manager,
+                ):
+                    response = client.get(
+                        f"{_expose(client, primary_port)}/redirect-health"
+                    )
+                    assert response.status_code == 502
+                    assert victim_app.state.hits == 0
+
+    def test_relative_redirect_stays_beneath_capability_url(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            response = client.get(f"{_expose(client, port)}/relative-redirect")
+            assert response.status_code == 200
+            assert response.json() == {"status": "healthy"}
+
+    def test_readiness_probe_does_not_follow_redirect(self):
+        victim = _build_upstream_app()
+        with running_upstream(victim) as (victim_port, victim_app):
+            target = f"http://127.0.0.1:{victim_port}"
+            primary = _build_upstream_app(target)
+            with running_upstream(primary) as (primary_port, _primary_app):
+                with orchestrator_client(primary_port) as (
+                    client,
+                    services,
+                    _manager,
+                ):
+                    response = client.post(
+                        f"/sandboxes/{SANDBOX_ID}/services",
+                        json={
+                            "port": primary_port,
+                            "wait_ready": True,
+                            "health_path": "/redirect-health",
+                            "ready_timeout": 1,
+                        },
+                        headers=AUTH,
+                    )
+                    assert response.status_code == 408
+                    assert victim_app.state.hits == 0
+                    assert services == {}
+
+    @requires_websockets
+    def test_websocket_redirect_cannot_leave_pinned_port(self):
+        victim = _build_upstream_app()
+        with running_upstream(victim) as (victim_port, victim_app):
+            target = f"http://127.0.0.1:{victim_port}"
+            primary = _build_upstream_app(target)
+            with running_upstream(primary) as (primary_port, _primary_app):
+                with orchestrator_client(primary_port) as (
+                    client,
+                    _services,
+                    _manager,
+                ):
+                    base = _expose(client, primary_port).replace("http:", "ws:")
+                    with pytest.raises(WebSocketDisconnect) as excinfo:
+                        with client.websocket_connect(f"{base}/ws-redirect"):
+                            pass
+                    assert excinfo.value.code == 4503
+                    assert victim_app.state.ws_hits == 0
 
 
 class TestWebSocketProxy:
     @requires_websockets
-    def test_text_frames_round_trip(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            with client.websocket_connect(f"{base}/ws") as ws:
+    def test_text_binary_subprotocol_close_and_heartbeat(self, upstream):
+        port, app = upstream
+        with orchestrator_client(port) as (client, _services, manager):
+            base = _expose(client, port).replace("http:", "ws:")
+            with client.websocket_connect(
+                f"{base}/ws",
+                subprotocols=[f"api_key.{API_KEY}", "openenv-v1"],
+            ) as ws:
+                assert ws.accepted_subprotocol == "openenv-v1"
+                assert app.state.last_protocols == "openenv-v1"
                 ws.send_text("hello")
                 assert ws.receive_text() == "echo:hello"
-
-    @requires_websockets
-    def test_many_frames_round_trip(self, upstream):
-        """A persistent session, which is how an RL rollout drives an env."""
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            with client.websocket_connect(f"{base}/ws") as ws:
-                for index in range(25):
-                    ws.send_text(f"m{index}")
-                    assert ws.receive_text() == f"echo:m{index}"
-
-    @requires_websockets
-    def test_binary_frames_round_trip(self, upstream):
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            with client.websocket_connect(f"{base}/ws") as ws:
-                ws.send_bytes(b"\x00\x01\x02")
-                assert ws.receive_bytes() == b"bin:\x00\x01\x02"
-
-    @requires_websockets
-    def test_upstream_close_code_is_propagated(self, upstream):
-        """A client must be able to tell a clean close from a proxy failure."""
-        from starlette.websockets import WebSocketDisconnect
-
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            with client.websocket_connect(f"{base}/ws") as ws:
+                ws.send_bytes(b"\x00\x01")
+                assert ws.receive_bytes() == b"bin:\x00\x01"
+                ws.send_text("wait")
+                assert ws.receive_text() == "echo:wait"
+                assert manager.heartbeat.await_count >= 2
                 ws.send_text("close-please")
                 with pytest.raises(WebSocketDisconnect) as excinfo:
                     ws.receive_text()
-            assert excinfo.value.code == 4200
+                assert excinfo.value.code == 4200
 
-    def test_forged_token_refused_before_accept(self, upstream):
-        from starlette.websockets import WebSocketDisconnect
+    @requires_websockets
+    def test_revocation_closes_an_established_socket(self, upstream):
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port).replace("http:", "ws:")
+            with client.websocket_connect(f"{base}/ws") as ws:
+                client.delete(f"/sandboxes/{SANDBOX_ID}/services/{port}", headers=AUTH)
+                with pytest.raises(WebSocketDisconnect) as excinfo:
+                    ws.receive_text()
+                assert excinfo.value.code == 4403
 
-        with orchestrator_client(upstream) as (client, _):
-            with pytest.raises(WebSocketDisconnect) as excinfo:
-                with client.websocket_connect("/s/bogus-token/ws"):
-                    pass
-            assert excinfo.value.code == 4403
+    @requires_websockets
+    def test_handshake_has_a_deadline(self, upstream):
+        import orchard_env.orchestrator.api as api_module
 
-    def test_revoked_port_refuses_new_sockets(self, upstream):
-        from starlette.websockets import WebSocketDisconnect
-
-        with orchestrator_client(upstream) as (client, _):
-            base = _expose(client, upstream)
-            client.delete(f"/sandboxes/{SANDBOX_ID}/services/{upstream}", headers=AUTH)
-            with pytest.raises(WebSocketDisconnect) as excinfo:
-                with client.websocket_connect(f"{base}/ws"):
-                    pass
-            assert excinfo.value.code == 4403
+        port, _app = upstream
+        with orchestrator_client(port) as (client, _services, _manager):
+            base = _expose(client, port).replace("http:", "ws:")
+            with patch.object(
+                api_module.settings,
+                "service_proxy_handshake_timeout_seconds",
+                0.05,
+            ):
+                with pytest.raises(WebSocketDisconnect) as excinfo:
+                    with client.websocket_connect(f"{base}/ws-hang"):
+                        pass
+            assert excinfo.value.code == 4503

--- a/orchard_env/tests/test_service_proxy.py
+++ b/orchard_env/tests/test_service_proxy.py
@@ -1,8 +1,4 @@
-"""Unit tests for the sandbox service proxy helpers.
-
-Covers the pure logic a reviewer most wants pinned down: which ports may be
-opened, which headers must not be forwarded, and how upstream URLs are built.
-"""
+"""Unit tests for sandbox service proxy helpers."""
 
 from unittest.mock import patch
 
@@ -15,6 +11,7 @@ from orchard_env.orchestrator.service_proxy import (
     build_upstream_url,
     filter_request_headers,
     filter_response_headers,
+    filter_websocket_headers,
     validate_port,
 )
 
@@ -33,7 +30,6 @@ class TestValidatePort:
             validate_port(port)
 
     def test_agent_port_always_rejected(self):
-        """Exposing the agent would hand out unauthenticated exec in the pod."""
         with pytest.raises(ServicePortError, match="reserved for the in-pod"):
             validate_port(service_proxy.settings.agent_port)
 
@@ -48,17 +44,8 @@ class TestValidatePort:
                 validate_port(6379)
             assert validate_port(8000) == 8000
 
-    def test_reserved_list_tolerates_junk(self):
-        with patch.object(
-            service_proxy.settings, "service_reserved_ports", "22 notaport 6379"
-        ):
-            assert validate_port(8000) == 8000
-            with pytest.raises(ServicePortError):
-                validate_port(22)
-
     @pytest.mark.parametrize("port", ["8000", None, 80.5, True])
     def test_non_integer_rejected(self, port):
-        # `True` is int-like in Python; a bool is never a deliberate port.
         with pytest.raises(ServicePortError):
             validate_port(port)
 
@@ -73,18 +60,38 @@ class TestHeaderFiltering:
                 "Content-Type": "application/json",
             }
         )
-        assert filtered == {"Content-Type": "application/json"}
+        assert filtered == [("Content-Type", "application/json")]
 
-    def test_host_and_content_length_dropped_from_request(self):
-        """Both describe the client's hop; aiohttp recomputes them upstream."""
+    def test_host_and_content_length_dropped(self):
         filtered = filter_request_headers(
             {"Host": "orchestrator", "Content-Length": "12", "X-Trace": "abc"}
         )
-        assert filtered == {"X-Trace": "abc"}
+        assert filtered == [("X-Trace", "abc")]
 
-    def test_filtering_is_case_insensitive(self):
-        filtered = filter_request_headers({"CoNnEcTiOn": "keep-alive", "A": "b"})
-        assert filtered == {"A": "b"}
+    def test_management_credentials_are_never_forwarded(self):
+        filtered = filter_request_headers(
+            {
+                "Authorization": "Bearer secret",
+                "Cookie": "session=secret",
+                "X-API-Key": "management-key",
+                "X-Custom": "safe",
+            }
+        )
+        assert filtered == [("X-Custom", "safe")]
+
+    def test_fields_named_by_connection_are_dropped(self):
+        filtered = filter_request_headers(
+            [
+                ("Connection", "X-Remove, keep-alive"),
+                ("X-Remove", "secret"),
+                ("X-Keep", "value"),
+            ]
+        )
+        assert filtered == [("X-Keep", "value")]
+
+    def test_duplicate_request_headers_are_preserved(self):
+        filtered = filter_request_headers([("X-Value", "one"), ("X-Value", "two")])
+        assert filtered == [("X-Value", "one"), ("X-Value", "two")]
 
     def test_response_hop_by_hop_headers_dropped(self):
         filtered = filter_response_headers(
@@ -94,50 +101,92 @@ class TestHeaderFiltering:
                 "Content-Type": "text/html",
             }
         )
-        assert filtered == {"Content-Type": "text/html"}
+        assert filtered == [("Content-Type", "text/html")]
 
-    def test_content_headers_survive_the_response(self):
-        """The body is relayed unmodified, so these still describe it. Dropping
-        Content-Encoding would hand the client undecodable compressed bytes."""
+    def test_content_headers_survive(self):
         filtered = filter_response_headers(
             {"Content-Length": "100", "Content-Encoding": "gzip"}
         )
-        assert filtered == {"Content-Length": "100", "Content-Encoding": "gzip"}
+        assert filtered == [
+            ("Content-Length", "100"),
+            ("Content-Encoding", "gzip"),
+        ]
 
-    def test_ordinary_headers_survive_both_directions(self):
-        headers = {"Authorization": "Bearer x", "X-Custom": "1"}
-        assert filter_request_headers(headers) == headers
-        assert filter_response_headers(headers) == headers
+    def test_unsafe_browser_state_headers_are_dropped(self):
+        filtered = filter_response_headers(
+            [
+                ("Set-Cookie", "session=hostile; Domain=.example.com"),
+                ("Service-Worker-Allowed", "/"),
+                ("X-Custom", "1"),
+            ]
+        )
+        assert filtered == [("X-Custom", "1")]
+
+    def test_duplicate_response_headers_are_preserved(self):
+        filtered = filter_response_headers([("Link", "</one>"), ("Link", "</two>")])
+        assert filtered == [("Link", "</one>"), ("Link", "</two>")]
+
+    def test_websocket_headers_use_a_safe_allowlist(self):
+        filtered = filter_websocket_headers(
+            {
+                "User-Agent": "browser",
+                "Authorization": "Bearer secret",
+                "Cookie": "secret=1",
+                "X-Request-ID": "r1",
+            }
+        )
+        assert filtered == [("User-Agent", "browser"), ("X-Request-ID", "r1")]
 
 
 class TestUrlBuilding:
     def test_path_without_leading_slash_is_normalised(self):
-        assert build_upstream_url("10.0.0.1", 8000, "health") == (
+        assert str(build_upstream_url("10.0.0.1", 8000, "health")) == (
             "http://10.0.0.1:8000/health"
         )
 
     def test_leading_slash_preserved(self):
-        assert build_upstream_url("10.0.0.1", 8000, "/health") == (
+        assert str(build_upstream_url("10.0.0.1", 8000, "/health")) == (
             "http://10.0.0.1:8000/health"
         )
 
     def test_empty_path_becomes_root(self):
-        assert build_upstream_url("10.0.0.1", 8000, "") == "http://10.0.0.1:8000/"
+        assert str(build_upstream_url("10.0.0.1", 8000, "")) == "http://10.0.0.1:8000/"
 
     def test_query_string_passed_through_verbatim(self):
-        url = build_upstream_url("10.0.0.1", 8000, "/search", "q=a+b&n=1")
-        assert url == "http://10.0.0.1:8000/search?q=a+b&n=1"
+        url = build_upstream_url(
+            "10.0.0.1", 8000, "/search", raw_query_string="q=a+b&n=1"
+        )
+        assert str(url) == "http://10.0.0.1:8000/search?q=a+b&n=1"
 
     def test_ws_scheme_supported(self):
         url = build_upstream_url("10.0.0.1", 8000, "/ws", scheme="ws")
-        assert url == "ws://10.0.0.1:8000/ws"
+        assert str(url) == "ws://10.0.0.1:8000/ws"
+
+    def test_encoded_delimiters_remain_encoded(self):
+        url = build_upstream_url(
+            "10.0.0.1",
+            8000,
+            "/objects/a%2Fb%3Fc%23d",
+            raw_query_string="sig=a%2Fb",
+        )
+        assert str(url) == ("http://10.0.0.1:8000/objects/a%2Fb%3Fc%23d?sig=a%2Fb")
 
     def test_service_url_puts_token_in_path(self):
-        """A client appending its own suffix must produce a working URL."""
-        url = build_service_url("https://orchestrator.example.com", "tok123")
-        assert url == "https://orchestrator.example.com/s/tok123"
-        # This is exactly what an OpenEnv EnvClient does:
-        assert f"{url}/ws" == "https://orchestrator.example.com/s/tok123/ws"
+        url = build_service_url("https://{subdomain}.services.example.net", "tok123")
+        assert url.endswith(".services.example.net/s/tok123")
+        assert url.startswith("https://")
+        assert f"{url}/ws".endswith("/s/tok123/ws")
 
     def test_service_url_tolerates_trailing_slash(self):
-        assert build_service_url("https://host/", "tok") == "https://host/s/tok"
+        url = build_service_url("https://{subdomain}.example.net/", "tok")
+        assert url.endswith(".example.net/s/tok")
+
+
+def test_orchestrator_access_log_is_disabled():
+    """Generic access logs would disclose /s/<capability>/... request paths."""
+    from orchard_env.orchestrator import main
+
+    with patch.object(main.uvicorn, "run") as run:
+        main.main()
+    assert run.call_args.kwargs["access_log"] is False
+    assert run.call_args.kwargs["log_level"] == "warning"

--- a/orchard_env/tests/test_service_proxy.py
+++ b/orchard_env/tests/test_service_proxy.py
@@ -1,0 +1,143 @@
+"""Unit tests for the sandbox service proxy helpers.
+
+Covers the pure logic a reviewer most wants pinned down: which ports may be
+opened, which headers must not be forwarded, and how upstream URLs are built.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from orchard_env.orchestrator import service_proxy
+from orchard_env.orchestrator.service_proxy import (
+    ServicePortError,
+    build_service_url,
+    build_upstream_url,
+    filter_request_headers,
+    filter_response_headers,
+    validate_port,
+)
+
+
+class TestValidatePort:
+    def test_ordinary_port_allowed(self):
+        assert validate_port(8000) == 8000
+
+    @pytest.mark.parametrize("port", [1, 65535])
+    def test_boundaries_allowed(self, port):
+        assert validate_port(port) == port
+
+    @pytest.mark.parametrize("port", [0, -1, 65536, 99999])
+    def test_out_of_range_rejected(self, port):
+        with pytest.raises(ServicePortError, match="valid range"):
+            validate_port(port)
+
+    def test_agent_port_always_rejected(self):
+        """Exposing the agent would hand out unauthenticated exec in the pod."""
+        with pytest.raises(ServicePortError, match="reserved for the in-pod"):
+            validate_port(service_proxy.settings.agent_port)
+
+    def test_agent_port_rejected_even_when_reconfigured(self):
+        with patch.object(service_proxy.settings, "agent_port", 7777):
+            with pytest.raises(ServicePortError, match="reserved for the in-pod"):
+                validate_port(7777)
+
+    def test_operator_reserved_ports_rejected(self):
+        with patch.object(service_proxy.settings, "service_reserved_ports", "22, 6379"):
+            with pytest.raises(ServicePortError, match="reserved"):
+                validate_port(6379)
+            assert validate_port(8000) == 8000
+
+    def test_reserved_list_tolerates_junk(self):
+        with patch.object(
+            service_proxy.settings, "service_reserved_ports", "22 notaport 6379"
+        ):
+            assert validate_port(8000) == 8000
+            with pytest.raises(ServicePortError):
+                validate_port(22)
+
+    @pytest.mark.parametrize("port", ["8000", None, 80.5, True])
+    def test_non_integer_rejected(self, port):
+        # `True` is int-like in Python; a bool is never a deliberate port.
+        with pytest.raises(ServicePortError):
+            validate_port(port)
+
+
+class TestHeaderFiltering:
+    def test_hop_by_hop_request_headers_dropped(self):
+        filtered = filter_request_headers(
+            {
+                "Connection": "keep-alive",
+                "Upgrade": "websocket",
+                "Transfer-Encoding": "chunked",
+                "Content-Type": "application/json",
+            }
+        )
+        assert filtered == {"Content-Type": "application/json"}
+
+    def test_host_and_content_length_dropped_from_request(self):
+        """Both describe the client's hop; aiohttp recomputes them upstream."""
+        filtered = filter_request_headers(
+            {"Host": "orchestrator", "Content-Length": "12", "X-Trace": "abc"}
+        )
+        assert filtered == {"X-Trace": "abc"}
+
+    def test_filtering_is_case_insensitive(self):
+        filtered = filter_request_headers({"CoNnEcTiOn": "keep-alive", "A": "b"})
+        assert filtered == {"A": "b"}
+
+    def test_response_hop_by_hop_headers_dropped(self):
+        filtered = filter_response_headers(
+            {
+                "Transfer-Encoding": "chunked",
+                "Connection": "close",
+                "Content-Type": "text/html",
+            }
+        )
+        assert filtered == {"Content-Type": "text/html"}
+
+    def test_content_headers_survive_the_response(self):
+        """The body is relayed unmodified, so these still describe it. Dropping
+        Content-Encoding would hand the client undecodable compressed bytes."""
+        filtered = filter_response_headers(
+            {"Content-Length": "100", "Content-Encoding": "gzip"}
+        )
+        assert filtered == {"Content-Length": "100", "Content-Encoding": "gzip"}
+
+    def test_ordinary_headers_survive_both_directions(self):
+        headers = {"Authorization": "Bearer x", "X-Custom": "1"}
+        assert filter_request_headers(headers) == headers
+        assert filter_response_headers(headers) == headers
+
+
+class TestUrlBuilding:
+    def test_path_without_leading_slash_is_normalised(self):
+        assert build_upstream_url("10.0.0.1", 8000, "health") == (
+            "http://10.0.0.1:8000/health"
+        )
+
+    def test_leading_slash_preserved(self):
+        assert build_upstream_url("10.0.0.1", 8000, "/health") == (
+            "http://10.0.0.1:8000/health"
+        )
+
+    def test_empty_path_becomes_root(self):
+        assert build_upstream_url("10.0.0.1", 8000, "") == "http://10.0.0.1:8000/"
+
+    def test_query_string_passed_through_verbatim(self):
+        url = build_upstream_url("10.0.0.1", 8000, "/search", "q=a+b&n=1")
+        assert url == "http://10.0.0.1:8000/search?q=a+b&n=1"
+
+    def test_ws_scheme_supported(self):
+        url = build_upstream_url("10.0.0.1", 8000, "/ws", scheme="ws")
+        assert url == "ws://10.0.0.1:8000/ws"
+
+    def test_service_url_puts_token_in_path(self):
+        """A client appending its own suffix must produce a working URL."""
+        url = build_service_url("https://orchestrator.example.com", "tok123")
+        assert url == "https://orchestrator.example.com/s/tok123"
+        # This is exactly what an OpenEnv EnvClient does:
+        assert f"{url}/ws" == "https://orchestrator.example.com/s/tok123/ws"
+
+    def test_service_url_tolerates_trailing_slash(self):
+        assert build_service_url("https://host/", "tok") == "https://host/s/tok"

--- a/orchard_env/tests/test_service_security.py
+++ b/orchard_env/tests/test_service_security.py
@@ -1,0 +1,169 @@
+"""Deployment-level security invariants used by service endpoints."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import requests
+import yaml
+
+from orchard_env.client.sandbox_client import _ScopedApiKeySession
+from orchard_env.orchestrator.k8s_client import K8sClient
+from orchard_env.orchestrator.redis_connection import redis_log_target
+from orchard_env.orchestrator.redis_job_store import RedisJobStore
+from orchard_env.orchestrator.redis_store import RedisSandboxStore
+from orchard_env.orchestrator.utils import CapabilityPathRedactionFilter
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sdk_api_key_is_scoped_to_management_origin():
+    session = _ScopedApiKeySession("https://api.example.com", "secret")
+    management = session.prepare_request(
+        requests.Request("GET", "https://api.example.com/health")
+    )
+    service = session.prepare_request(
+        requests.Request("GET", "https://cap.sandboxes.example.net/s/token")
+    )
+    assert management.headers["X-API-Key"] == "secret"
+    assert "X-API-Key" not in service.headers
+
+
+def test_capability_path_is_redacted_from_log_message_and_arguments():
+    import logging
+
+    token = "payload.signature"
+    record = logging.LogRecord(
+        "uvicorn.error",
+        logging.INFO,
+        __file__,
+        1,
+        'WebSocket "%s"',
+        (f"/s/{token}/ws?x=1",),
+        None,
+    )
+    assert CapabilityPathRedactionFilter().filter(record)
+    assert token not in record.getMessage()
+    assert "/s/<redacted>/ws?x=1" in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_pod_overrides_image_agent_port():
+    """An arbitrary image's AGENT_PORT cannot move the trusted agent."""
+    captured = {}
+    k8s = object.__new__(K8sClient)
+    core = SimpleNamespace(create_namespaced_pod=object())
+    k8s._get_core_v1_api = lambda: core
+
+    async def k8s_call(_method, **kwargs):
+        captured.update(kwargs)
+
+    k8s._k8s_call = k8s_call
+    with (
+        patch(
+            "orchard_env.orchestrator.k8s_client.settings.enable_sandbox_tools",
+            False,
+        ),
+        patch(
+            "orchard_env.orchestrator.k8s_client.settings.agent_port",
+            9090,
+        ),
+    ):
+        await k8s.create_pod(
+            name="sandbox-s1",
+            namespace="sandbox-pods",
+            image="hostile-image:latest",
+            sandbox_id="s1",
+        )
+
+    container = captured["body"].spec.containers[0]
+    assert {item.name: item.value for item in container.env} == {"AGENT_PORT": "9090"}
+    assert container.ports[0].container_port == 9090
+
+
+def test_redis_network_policy_allows_only_orchestrator_pods():
+    documents = list(yaml.safe_load_all((ROOT / "k8s/redis.yaml").read_text()))
+    policy = next(item for item in documents if item["kind"] == "NetworkPolicy")
+    assert policy["spec"]["podSelector"]["matchLabels"] == {"app": "redis"}
+    assert policy["spec"]["policyTypes"] == ["Ingress"]
+    peer = policy["spec"]["ingress"][0]["from"][0]
+    assert peer == {"podSelector": {"matchLabels": {"app": "sandbox-orchestrator"}}}
+    assert policy["spec"]["ingress"][0]["ports"] == [{"protocol": "TCP", "port": 6379}]
+
+
+@pytest.mark.asyncio
+async def test_redis_authentication_fails_closed_when_missing():
+    store = RedisSandboxStore("redis://redis.example:6379/0")
+    with (
+        patch("orchard_env.orchestrator.redis_store.settings.redis_require_auth", True),
+        patch("orchard_env.orchestrator.redis_store.settings.redis_password", None),
+    ):
+        with pytest.raises(RuntimeError, match="authentication is required"):
+            await store.connect()
+
+
+@pytest.mark.asyncio
+async def test_redis_password_is_passed_out_of_band():
+    store = RedisSandboxStore("redis://redis.example:6379/0")
+    client = AsyncMock()
+    with (
+        patch("orchard_env.orchestrator.redis_store.settings.redis_require_auth", True),
+        patch("orchard_env.orchestrator.redis_store.settings.redis_password", "secret"),
+        patch(
+            "orchard_env.orchestrator.redis_connection.redis.from_url",
+            return_value=client,
+        ) as from_url,
+    ):
+        await store.connect()
+
+    assert from_url.call_args.kwargs["password"] == "secret"
+    client.ping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_password_embedded_in_redis_url_is_preserved():
+    store = RedisSandboxStore("redis://:url-secret@redis.example:6379/0")
+    client = AsyncMock()
+    with (
+        patch("orchard_env.orchestrator.redis_store.settings.redis_require_auth", True),
+        patch("orchard_env.orchestrator.redis_store.settings.redis_password", None),
+        patch(
+            "orchard_env.orchestrator.redis_connection.redis.from_url",
+            return_value=client,
+        ) as from_url,
+    ):
+        await store.connect()
+
+    assert "password" not in from_url.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_redis_job_store_uses_shared_authenticated_factory():
+    store = RedisJobStore("redis://redis.example:6379/0")
+    client = AsyncMock()
+    with (
+        patch(
+            "orchard_env.orchestrator.redis_connection.settings.redis_require_auth",
+            True,
+        ),
+        patch(
+            "orchard_env.orchestrator.redis_connection.settings.redis_password",
+            "secret",
+        ),
+        patch(
+            "orchard_env.orchestrator.redis_connection.redis.from_url",
+            return_value=client,
+        ) as from_url,
+    ):
+        await store.connect()
+
+    assert from_url.call_args.kwargs["password"] == "secret"
+    client.ping.assert_awaited_once()
+
+
+def test_redis_log_target_never_contains_credentials():
+    target = redis_log_target("rediss://user:secret@redis.example:6380/2")
+    assert target == "rediss://redis.example:6380/2"
+    assert "user" not in target
+    assert "secret" not in target

--- a/orchard_env/tests/test_service_tokens.py
+++ b/orchard_env/tests/test_service_tokens.py
@@ -1,9 +1,4 @@
-"""Unit tests for sandbox service capability tokens.
-
-The token *is* the credential in a service URL, so these tests concentrate on
-the ways a token could wrongly be accepted: a forged signature, a tampered
-payload, a stale expiry, or a token minted for a different sandbox or port.
-"""
+"""Unit tests for sandbox service capability tokens."""
 
 import time
 from unittest.mock import patch
@@ -17,10 +12,11 @@ from orchard_env.orchestrator.service_tokens import (
     verify_token,
 )
 
+GENERATION = "generation-1"
+
 
 @pytest.fixture(autouse=True)
 def fixed_secret():
-    """Pin the signing key so tests do not depend on ambient configuration."""
     with patch.object(
         service_tokens.settings, "service_token_secret", "test-secret-key"
     ):
@@ -28,37 +24,54 @@ def fixed_secret():
 
 
 class TestRoundTrip:
-    def test_mint_and_verify_returns_sandbox_and_port(self):
-        token, expires_at = mint_token("sandbox-abc", 8000)
-        assert verify_token(token) == ("sandbox-abc", 8000)
+    def test_mint_and_verify_returns_bound_values(self):
+        token, expires_at = mint_token("sandbox-abc", 8000, GENERATION)
+        assert verify_token(token) == (
+            "sandbox-abc",
+            8000,
+            GENERATION,
+            int(expires_at),
+        )
         assert expires_at > time.time()
 
     def test_token_has_two_base64url_segments(self):
-        token, _ = mint_token("sandbox-abc", 8000)
+        token, _ = mint_token("sandbox-abc", 8000, GENERATION)
         payload, separator, signature = token.partition(".")
         assert separator == "."
         assert payload and signature
-        # base64url alphabet only: safe to embed in a URL path unescaped.
         assert all(c.isalnum() or c in "-_" for c in payload + signature)
 
-    def test_sandbox_ids_containing_colons_survive(self):
-        # The payload is colon-delimited and parsed right-to-left, so a colon
-        # inside the sandbox id must not shift the port or expiry fields.
-        token, _ = mint_token("weird:id:with:colons", 8000)
-        assert verify_token(token) == ("weird:id:with:colons", 8000)
+    def test_arbitrary_sandbox_id_round_trips(self):
+        token, _ = mint_token("weird:id/with spaces", 8000, GENERATION)
+        sandbox_id, port, generation, _expires_at = verify_token(token)
+        assert (sandbox_id, port, generation) == (
+            "weird:id/with spaces",
+            8000,
+            GENERATION,
+        )
 
     def test_explicit_ttl_is_honoured(self):
-        _token, expires_at = mint_token("sandbox-abc", 8000, ttl_seconds=120)
+        _token, expires_at = mint_token(
+            "sandbox-abc", 8000, GENERATION, ttl_seconds=120
+        )
         assert 110 < expires_at - time.time() <= 120
+
+    @pytest.mark.parametrize(
+        ("sandbox_id", "generation"),
+        [("", GENERATION), ("sandbox-abc", "")],
+    )
+    def test_empty_bound_value_rejected(self, sandbox_id, generation):
+        with pytest.raises(ValueError):
+            mint_token(sandbox_id, 8000, generation)
 
     def test_non_positive_ttl_rejected(self):
         with pytest.raises(ValueError):
-            mint_token("sandbox-abc", 8000, ttl_seconds=0)
+            mint_token("sandbox-abc", 8000, GENERATION, ttl_seconds=0)
 
 
 class TestRejection:
     def test_expired_token_rejected(self):
-        token, _ = mint_token("sandbox-abc", 8000, ttl_seconds=1)
+        token, _ = mint_token("sandbox-abc", 8000, GENERATION, ttl_seconds=1)
         future = time.time() + 3600
         with patch(
             "orchard_env.orchestrator.service_tokens.time.time", return_value=future
@@ -67,17 +80,16 @@ class TestRejection:
                 verify_token(token)
 
     def test_tampered_payload_rejected(self):
-        token, _ = mint_token("sandbox-abc", 8000)
-        payload, _, signature = token.partition(".")
-        forged_payload, _ = mint_token("sandbox-victim", 9999)
+        token, _ = mint_token("sandbox-abc", 8000, GENERATION)
+        _, _, signature = token.partition(".")
+        forged_payload, _ = mint_token("sandbox-victim", 9999, "other")
         tampered = f"{forged_payload.partition('.')[0]}.{signature}"
-        assert tampered != token
         with pytest.raises(ServiceTokenError, match="signature"):
             verify_token(tampered)
 
     def test_token_signed_with_another_secret_rejected(self):
         with patch.object(service_tokens.settings, "service_token_secret", "other-key"):
-            token, _ = mint_token("sandbox-abc", 8000)
+            token, _ = mint_token("sandbox-abc", 8000, GENERATION)
         with pytest.raises(ServiceTokenError, match="signature"):
             verify_token(token)
 
@@ -88,47 +100,7 @@ class TestRejection:
         with pytest.raises(ServiceTokenError):
             verify_token(bad)
 
-    def test_empty_sandbox_id_rejected(self):
-        # Guards against a token whose payload decodes but names nothing.
-        token, _ = mint_token("", 8000)
-        with pytest.raises(ServiceTokenError):
-            verify_token(token)
-
-
-class TestSecretDerivation:
-    def test_api_keys_derive_a_stable_secret(self):
-        """Replicas sharing API keys must validate each other's tokens."""
+    def test_missing_secret_fails_closed(self):
         with patch.object(service_tokens.settings, "service_token_secret", None):
-            with patch.object(service_tokens.settings, "api_keys", "k1,k2"):
-                token, _ = mint_token("sandbox-abc", 8000)
-                assert verify_token(token) == ("sandbox-abc", 8000)
-
-    def test_derived_secret_is_not_the_api_key_itself(self):
-        with patch.object(service_tokens.settings, "service_token_secret", None):
-            with patch.object(service_tokens.settings, "api_keys", "k1"):
-                derived = service_tokens._signing_secret()
-        assert derived != b"k1"
-
-    def test_key_order_does_not_change_the_secret(self):
-        with patch.object(service_tokens.settings, "service_token_secret", None):
-            with patch.object(service_tokens.settings, "api_keys", "a,b"):
-                first = service_tokens._signing_secret()
-            with patch.object(service_tokens.settings, "api_keys", "b,a"):
-                second = service_tokens._signing_secret()
-        assert first == second
-
-    def test_different_api_keys_produce_different_secrets(self):
-        with patch.object(service_tokens.settings, "service_token_secret", None):
-            with patch.object(service_tokens.settings, "api_keys", "a"):
-                first = service_tokens._signing_secret()
-            with patch.object(service_tokens.settings, "api_keys", "b"):
-                second = service_tokens._signing_secret()
-        assert first != second
-
-    def test_process_secret_used_as_last_resort(self):
-        service_tokens._PROCESS_SECRET = None
-        with patch.object(service_tokens.settings, "service_token_secret", None):
-            with patch.object(service_tokens.settings, "api_keys", None):
-                token, _ = mint_token("sandbox-abc", 8000)
-                assert verify_token(token) == ("sandbox-abc", 8000)
-        service_tokens._PROCESS_SECRET = None
+            with pytest.raises(ServiceTokenError, match="required"):
+                mint_token("sandbox-abc", 8000, GENERATION)

--- a/orchard_env/tests/test_service_tokens.py
+++ b/orchard_env/tests/test_service_tokens.py
@@ -1,0 +1,134 @@
+"""Unit tests for sandbox service capability tokens.
+
+The token *is* the credential in a service URL, so these tests concentrate on
+the ways a token could wrongly be accepted: a forged signature, a tampered
+payload, a stale expiry, or a token minted for a different sandbox or port.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from orchard_env.orchestrator import service_tokens
+from orchard_env.orchestrator.service_tokens import (
+    ServiceTokenError,
+    mint_token,
+    verify_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixed_secret():
+    """Pin the signing key so tests do not depend on ambient configuration."""
+    with patch.object(
+        service_tokens.settings, "service_token_secret", "test-secret-key"
+    ):
+        yield
+
+
+class TestRoundTrip:
+    def test_mint_and_verify_returns_sandbox_and_port(self):
+        token, expires_at = mint_token("sandbox-abc", 8000)
+        assert verify_token(token) == ("sandbox-abc", 8000)
+        assert expires_at > time.time()
+
+    def test_token_has_two_base64url_segments(self):
+        token, _ = mint_token("sandbox-abc", 8000)
+        payload, separator, signature = token.partition(".")
+        assert separator == "."
+        assert payload and signature
+        # base64url alphabet only: safe to embed in a URL path unescaped.
+        assert all(c.isalnum() or c in "-_" for c in payload + signature)
+
+    def test_sandbox_ids_containing_colons_survive(self):
+        # The payload is colon-delimited and parsed right-to-left, so a colon
+        # inside the sandbox id must not shift the port or expiry fields.
+        token, _ = mint_token("weird:id:with:colons", 8000)
+        assert verify_token(token) == ("weird:id:with:colons", 8000)
+
+    def test_explicit_ttl_is_honoured(self):
+        _token, expires_at = mint_token("sandbox-abc", 8000, ttl_seconds=120)
+        assert 110 < expires_at - time.time() <= 120
+
+    def test_non_positive_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            mint_token("sandbox-abc", 8000, ttl_seconds=0)
+
+
+class TestRejection:
+    def test_expired_token_rejected(self):
+        token, _ = mint_token("sandbox-abc", 8000, ttl_seconds=1)
+        future = time.time() + 3600
+        with patch(
+            "orchard_env.orchestrator.service_tokens.time.time", return_value=future
+        ):
+            with pytest.raises(ServiceTokenError, match="expired"):
+                verify_token(token)
+
+    def test_tampered_payload_rejected(self):
+        token, _ = mint_token("sandbox-abc", 8000)
+        payload, _, signature = token.partition(".")
+        forged_payload, _ = mint_token("sandbox-victim", 9999)
+        tampered = f"{forged_payload.partition('.')[0]}.{signature}"
+        assert tampered != token
+        with pytest.raises(ServiceTokenError, match="signature"):
+            verify_token(tampered)
+
+    def test_token_signed_with_another_secret_rejected(self):
+        with patch.object(service_tokens.settings, "service_token_secret", "other-key"):
+            token, _ = mint_token("sandbox-abc", 8000)
+        with pytest.raises(ServiceTokenError, match="signature"):
+            verify_token(token)
+
+    @pytest.mark.parametrize(
+        "bad", ["", "no-separator", ".", "abc.", ".abc", "!!!.???"]
+    )
+    def test_malformed_tokens_rejected(self, bad):
+        with pytest.raises(ServiceTokenError):
+            verify_token(bad)
+
+    def test_empty_sandbox_id_rejected(self):
+        # Guards against a token whose payload decodes but names nothing.
+        token, _ = mint_token("", 8000)
+        with pytest.raises(ServiceTokenError):
+            verify_token(token)
+
+
+class TestSecretDerivation:
+    def test_api_keys_derive_a_stable_secret(self):
+        """Replicas sharing API keys must validate each other's tokens."""
+        with patch.object(service_tokens.settings, "service_token_secret", None):
+            with patch.object(service_tokens.settings, "api_keys", "k1,k2"):
+                token, _ = mint_token("sandbox-abc", 8000)
+                assert verify_token(token) == ("sandbox-abc", 8000)
+
+    def test_derived_secret_is_not_the_api_key_itself(self):
+        with patch.object(service_tokens.settings, "service_token_secret", None):
+            with patch.object(service_tokens.settings, "api_keys", "k1"):
+                derived = service_tokens._signing_secret()
+        assert derived != b"k1"
+
+    def test_key_order_does_not_change_the_secret(self):
+        with patch.object(service_tokens.settings, "service_token_secret", None):
+            with patch.object(service_tokens.settings, "api_keys", "a,b"):
+                first = service_tokens._signing_secret()
+            with patch.object(service_tokens.settings, "api_keys", "b,a"):
+                second = service_tokens._signing_secret()
+        assert first == second
+
+    def test_different_api_keys_produce_different_secrets(self):
+        with patch.object(service_tokens.settings, "service_token_secret", None):
+            with patch.object(service_tokens.settings, "api_keys", "a"):
+                first = service_tokens._signing_secret()
+            with patch.object(service_tokens.settings, "api_keys", "b"):
+                second = service_tokens._signing_secret()
+        assert first != second
+
+    def test_process_secret_used_as_last_resort(self):
+        service_tokens._PROCESS_SECRET = None
+        with patch.object(service_tokens.settings, "service_token_secret", None):
+            with patch.object(service_tokens.settings, "api_keys", None):
+                token, _ = mint_token("sandbox-abc", 8000)
+                assert verify_token(token) == ("sandbox-abc", 8000)
+        service_tokens._PROCESS_SECRET = None


### PR DESCRIPTION
## Summary

Adds opt-in HTTP and WebSocket endpoints for long-running services inside Orchard sandboxes.

```python
sandbox.exec("nohup uvicorn server.app:app --host 0.0.0.0 --port 8000 &")
endpoint = sandbox.expose_service(8000, wait_ready=True)
# endpoint.url works for HTTP; endpoint.ws_url works for WebSocket clients.
```

This is the missing Orchard primitive for hosting protocol-driven environments such as OpenEnv servers. It is intentionally framework-neutral; OpenEnv, Tinker, and Ray adapters belong in follow-up PRs in their respective repositories.

## Design

- `POST /sandboxes/{id}/services` exposes an allowlisted port and returns a short-lived signed capability URL.
- HTTP and WebSocket traffic is proxied directly to the current pod IP.
- Revocation and expiry are enforced for active uploads, streams, and sockets.
- Re-exposing a revoked port rotates its generation, so old URLs remain invalid.
- Service state is separate from the sandbox record for rolling-upgrade compatibility.

## Security

- Disabled by default; requires a wildcard HTTPS service origin and explicit signing secret.
- Each capability receives a separate browser origin.
- Management credentials/cookies are never forwarded to sandbox code.
- Redirects cannot leave the exposed pod and port.
- Redis is authenticated and restricted to orchestrator pods in the reference manifests.
- Capability paths are redacted from application/Uvicorn logs; ingress logs must also redact `/s/*`.

## Validation

- 134 tests pass in a clean Linux container with real Kubernetes, aiohttp, Redis, and WebSocket dependencies.
- Black, Ruff, shell syntax, and Kubernetes YAML checks pass.
- Authenticated Redis 7 passed 20-way concurrent exposure, CAS, revocation-generation, and pod-incarnation checks.

## Follow-ups

1. OpenEnv `OrchardProvider` using this service URL contract.
2. Tinker `OrchardSandbox(SandboxInterface)` backend.
3. Optional Ray-backed rollout executor example for Tinker async RL.
